### PR TITLE
Using Unicode.GetByteCount to determine size of payload

### DIFF
--- a/src/NServiceBus.AmazonSQS/SqsMessageDispatcher.cs
+++ b/src/NServiceBus.AmazonSQS/SqsMessageDispatcher.cs
@@ -16,6 +16,7 @@
     using Logging;
     using Newtonsoft.Json;
     using Transport;
+    using static System.Text.Encoding;
 
     class SqsMessageDispatcher : IDispatchMessages
     {
@@ -35,7 +36,7 @@
                 {
                     var sqsTransportMessage = new SqsTransportMessage(unicastMessage.Message, unicastMessage.DeliveryConstraints);
                     var serializedMessage = JsonConvert.SerializeObject(sqsTransportMessage);
-                    if (serializedMessage.Length > 256 * 1024)
+                    if (Unicode.GetByteCount(serializedMessage) > MaximumPayloadSize)
                     {
                         if (string.IsNullOrEmpty(ConnectionConfiguration.S3BucketForLargeMessages))
                         {
@@ -99,6 +100,8 @@
 
             await SqsClient.SendMessageAsync(sendMessageRequest).ConfigureAwait(false);
         }
+
+        const int MaximumPayloadSize = 262144; //256 KB
 
         static ILog Logger = LogManager.GetLogger(typeof(SqsMessageDispatcher));
     }


### PR DESCRIPTION
string.Length represent the number of chars in a string. [MSDN explanation](https://msdn.microsoft.com/en-us/library/system.string.length.aspx)

> Gets the number of characters in the current String object.

a string is a sequence of UTF-16 code units, namely chars

> Represents text as a sequence of UTF-16 code units.

Therefore the more accurate way of determining the size of the payload is to use either

`string.Length * sizeof(char)`

or use the framework helper method

``` 
System.Text.Encoding.Unicode.GetByteCount(string)
```

We would be constantly determining right now the message size to be half of its actual message size. So a normal message might be reported as 1244 bytes but it would be actually 2488 bytes.