### PR TITLE
ConnectionConfiguration should only use the settings bag once

### DIFF
--- a/src/NServiceBus.AmazonSQS/AwsClientFactory.cs
+++ b/src/NServiceBus.AmazonSQS/AwsClientFactory.cs
@@ -16,8 +16,9 @@
                     return new EnvironmentVariablesAWSCredentials();
                 case SqsCredentialSource.InstanceProfile:
                     return new InstanceProfileAWSCredentials();
+                default:
+                    throw new NotImplementedException($"No implementation for credential type {connectionConfiguration.CredentialSource}");
             }
-            throw new NotImplementedException($"No implementation for credential type {connectionConfiguration.CredentialSource}");
         }
 
         static void SetProxyConfig(ClientConfig clientConfig, SqsConnectionConfiguration connectionConfig)

--- a/src/NServiceBus.AmazonSQS/SqsConnectionConfiguration.cs
+++ b/src/NServiceBus.AmazonSQS/SqsConnectionConfiguration.cs
@@ -5,30 +5,143 @@
 
     class SqsConnectionConfiguration
     {
-        public SqsConnectionConfiguration(SettingsHolder settingsHolder)
+        public SqsConnectionConfiguration(ReadOnlySettings settings)
         {
-            _settings = settingsHolder;
+            // Accessing the settings bag during runtime means a lot of boxing and unboxing, 
+            // all properties of this class are lazy initialized once they are accessed
+            this.settings = settings;
         }
 
-        public RegionEndpoint Region => _settings.Get<RegionEndpoint>(SqsTransportSettingsKeys.Region);
+        public RegionEndpoint Region
+        {
+            get
+            {
+                if (region == null)
+                {
+                    region = settings.Get<RegionEndpoint>(SqsTransportSettingsKeys.Region);
+                }
+                return region;
+            }
+        }
 
-        public int MaxTTLDays => _settings.GetOrDefault<int>(SqsTransportSettingsKeys.MaxTTLDays);
+        public int MaxTTLDays
+        {
+            get
+            {
+                if (!maxTtlDays.HasValue)
+                {
+                    maxTtlDays = settings.GetOrDefault<int>(SqsTransportSettingsKeys.MaxTTLDays);
+                }
+                return maxTtlDays.Value;
+            }
+        }
 
-        public string S3BucketForLargeMessages => _settings.GetOrDefault<string>(SqsTransportSettingsKeys.S3BucketForLargeMessages);
+        public string S3BucketForLargeMessages
+        {
+            get
+            {
+                if (s3BucketForLargeMessages == null)
+                {
+                    s3BucketForLargeMessages = settings.GetOrDefault<string>(SqsTransportSettingsKeys.S3BucketForLargeMessages);
+                }
+                return s3BucketForLargeMessages;
+            }
+        }
 
-        public string S3KeyPrefix => _settings.GetOrDefault<string>(SqsTransportSettingsKeys.S3KeyPrefix);
+        public string S3KeyPrefix
+        {
+            get
+            {
+                if (s3KeyPrefix == null)
+                {
+                    s3KeyPrefix = settings.GetOrDefault<string>(SqsTransportSettingsKeys.S3KeyPrefix);
+                }
+                return s3KeyPrefix;
+            }
+        }
 
-        public string QueueNamePrefix => _settings.GetOrDefault<string>(SqsTransportSettingsKeys.QueueNamePrefix);
+        public string QueueNamePrefix
+        {
+            get
+            {
+                if (queueNamePrefix == null)
+                {
+                    queueNamePrefix = settings.GetOrDefault<string>(SqsTransportSettingsKeys.QueueNamePrefix);
+                }
+                return queueNamePrefix;
+            }
+        }
 
-        public SqsCredentialSource CredentialSource => _settings.GetOrDefault<SqsCredentialSource>(SqsTransportSettingsKeys.CredentialSource);
+        public SqsCredentialSource CredentialSource
+        {
+            get
+            {
+                if (!credentialSource.HasValue)
+                {
+                    credentialSource = settings.GetOrDefault<SqsCredentialSource>(SqsTransportSettingsKeys.CredentialSource);
+                }
+                return credentialSource.Value;
+            }
+        }
 
-        public string ProxyHost => _settings.GetOrDefault<string>(SqsTransportSettingsKeys.ProxyHost);
+        public string ProxyHost
+        {
+            get
+            {
+                if (proxyHost == null)
+                {
+                    proxyHost = settings.GetOrDefault<string>(SqsTransportSettingsKeys.ProxyHost);
+                }
+                return proxyHost;
+            }
+        }
 
-        public int ProxyPort => _settings.GetOrDefault<int>(SqsTransportSettingsKeys.ProxyPort);
+        public int ProxyPort
+        {
+            get
+            {
+                if (!proxyPort.HasValue)
+                {
+                    proxyPort = settings.GetOrDefault<int>(SqsTransportSettingsKeys.ProxyPort);
+                }
+                return proxyPort.Value;
+            }
+        }
 
-        public bool NativeDeferral => _settings.GetOrDefault<bool>(SqsTransportSettingsKeys.NativeDeferral);
+        public bool NativeDeferral
+        {
+            get
+            {
+                if (!nativeDeferral.HasValue)
+                {
+                    nativeDeferral = settings.GetOrDefault<bool>(SqsTransportSettingsKeys.NativeDeferral);
+                }
+                return nativeDeferral.Value;
+            }
+        }
 
-        public bool PreTruncateQueueNames => _settings.GetOrDefault<bool>(SqsTransportSettingsKeys.PreTruncateQueueNames);
-        SettingsHolder _settings;
+        public bool PreTruncateQueueNames
+        {
+            get
+            {
+                if (!preTruncateQueueNames.HasValue)
+                {
+                    preTruncateQueueNames = settings.GetOrDefault<bool>(SqsTransportSettingsKeys.PreTruncateQueueNames);
+                }
+                return preTruncateQueueNames.Value;
+            }
+        }
+
+        RegionEndpoint region;
+        ReadOnlySettings settings;
+        int? maxTtlDays;
+        string s3BucketForLargeMessages;
+        string s3KeyPrefix;
+        string queueNamePrefix;
+        SqsCredentialSource? credentialSource;
+        string proxyHost;
+        int? proxyPort;
+        bool? nativeDeferral;
+        bool? preTruncateQueueNames;
     }
 }


### PR DESCRIPTION
Usage of SettingsHolder during runtime is discouraged since each call would potentially try to convert from object value to the destination type and allocate. We can do it once and then cache the value. We cannot do it in the constructor as of now since at the time when `SqsConnectionConfiguration `is created not all values might have been set.