### PR TITLE
NUnit Adapter test discovery failure

### DIFF
--- a/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
@@ -8,6 +8,10 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>    
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp11'">Full</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.3.4" />
     <PackageReference Include="NServiceBus" Version="6.3.4" />

--- a/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
@@ -15,8 +15,12 @@
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="AWSSDK.Core" version="3.3.12" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.5.12" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />    
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.6.0" />    
     <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp11'">Full</DebugType>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.3.4" />

--- a/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
+++ b/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp11'">Full</DebugType>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="6.3.4" />

--- a/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
+++ b/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
@@ -8,6 +8,10 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>    
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp11'">Full</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="6.3.4" />
     <PackageReference Include="NUnit" Version="3.6.1" />

--- a/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
+++ b/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
@@ -13,8 +13,12 @@
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="AWSSDK.Core" version="3.3.12" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.5.12" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />    
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.6.0" />    
     <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
+++ b/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
@@ -10,6 +10,10 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>    
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp11'">Full</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="6.3.4" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.3.4" />

--- a/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
+++ b/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
     <DebugSymbols>True</DebugSymbols>
+    <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
+    <DebugType>Full</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>PCR0001</NoWarn>
     <SignAssembly>true</SignAssembly>
@@ -15,8 +17,12 @@
     <PackageReference Include="AWSSDK.Core" version="3.3.12" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.5.12" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.6.0" />
     <ProjectReference Include="..\NServiceBus.AmazonSQS.AcceptanceTests\NServiceBus.AmazonSQS.AcceptanceTests.csproj" />    
     <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
+++ b/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
     <DebugSymbols>True</DebugSymbols>
-    <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
-    <DebugType>Full</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>PCR0001</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
+++ b/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp11'">Full</DebugType>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="6.3.4" />


### PR DESCRIPTION
* Add NUnit adapter as dependency to avoid machine config dependency and, in the future, support 'dotnet test'
* Workaround NUnit adapter test conversion failure

