### PR TITLE
Ignore machine name

### DIFF
--- a/src/NServiceBus.AmazonSQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.AmazonSQS/Configure/SqsTransport.cs
@@ -15,6 +15,8 @@
 
 		protected override void Configure(BusConfiguration config)
 		{
+            Address.IgnoreMachineName();
+
 			config.EnableFeature<SqsTransportFeature>();
 			config.EnableFeature<MessageDrivenSubscriptions>();
 		

--- a/src/NServiceBus.AmazonSQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.AmazonSQS/Configure/SqsTransport.cs
@@ -15,7 +15,7 @@
 
 		protected override void Configure(BusConfiguration config)
 		{
-            Address.IgnoreMachineName();
+			Address.IgnoreMachineName();
 
 			config.EnableFeature<SqsTransportFeature>();
 			config.EnableFeature<MessageDrivenSubscriptions>();


### PR DESCRIPTION
Ignore machine name when addressing. 
Fixes #128 

Users affected by this issue will need to manually fix any existing subscription stores that have multiple entries for the same endpoint (but with different machine names) - hence this is not necessarily a breaking change, rather some manual patching is required to take advantage of the fix.