### PR TITLE
SDK bump

### DIFF
--- a/packaging/nuget/nservicebus.amazonsqs.nuspec
+++ b/packaging/nuget/nservicebus.amazonsqs.nuspec
@@ -15,10 +15,10 @@
     <copyright>$copyright$</copyright>
     <tags>$tags$</tags>
     <dependencies>
-        <dependency id="AWSSDK.Core" version="3.3.12"/>
-        <dependency id="AWSSDK.S3" version="3.3.5.12"/>
-        <dependency id="AWSSDK.SQS" version="3.3.1.12"/>
         <dependency id="Newtonsoft.Json" version="[10.0.0, 11.0.0)"/>
+        <dependency id="AWSSDK.Core" version="[3.3.17.5, 3.4)"/>
+        <dependency id="AWSSDK.S3" version="[3.3.9, 3.4)"/>
+        <dependency id="AWSSDK.SQS" version="[3.3.2.7, 3.4)"/>
         <dependency id="NServiceBus" version="[6.0.0, 7.0.0)"/>
     </dependencies>
     <references></references>

--- a/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="NServiceBus" Version="6.3.4" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.3.4" />
     <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="AWSSDK.Core" version="3.3.12" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.5.12" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />
+    <PackageReference Include="AWSSDK.Core" version="3.3.17.5" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.9" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.2.7" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.6.0" />    
     <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
+++ b/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
     <PackageReference Include="NServiceBus" Version="6.3.4" />
     <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="AWSSDK.Core" version="3.3.12" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.5.12" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />
+    <PackageReference Include="AWSSDK.Core" version="3.3.17.5" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.9" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.2.7" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.6.0" />
     <PackageReference Include="PublicApiGenerator" Version="6.1.0-beta2" />    
     <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />

--- a/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
+++ b/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
@@ -16,9 +16,9 @@
     <PackageReference Include="NServiceBus" Version="6.3.4" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.3.4" />
     <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="AWSSDK.Core" version="3.3.12" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.5.12" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />
+    <PackageReference Include="AWSSDK.Core" version="3.3.17.5" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.9" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.2.7" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.6.0" />
     <ProjectReference Include="..\NServiceBus.AmazonSQS.AcceptanceTests\NServiceBus.AmazonSQS.AcceptanceTests.csproj" />    
     <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" />
     <PackageReference Include="NuGetPackager" Version="0.6.5" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" />
-    <PackageReference Include="AWSSDK.Core" version="3.3.12" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.5.12" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.1.12" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="AWSSDK.Core" version="3.3.17.5" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.9" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.2.7" />
     <None Include="..\..\GitVersion.yml" Link="GitVersion.yml" />
     <None Include="..\..\packaging\nuget\NServiceBus.AmazonSQS.nuspec" Link="NServiceBus.AmazonSQS.nuspec" />
   </ItemGroup>


### PR DESCRIPTION
https://github.com/aws/aws-sdk-net/issues/720 is clarified

Changed according to

> Use the [3.3, 3.4) range. Although I would suggest setting the min in the range to the latest version at the time of your release. There have been a lot of fixes done to the SDK since 3.3 came out and by default NuGet will pull in the lowest compatible dependency that satisfies all the dependencies.