### PR TITLE
When shutting down messages fetched should not be marked as poison

### DIFF
--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -108,6 +108,11 @@
 
                     var tasks = receiveResult.Messages.Select(async message =>
                     {
+                        if (cancellationTokenSource.Token.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
                         IncomingMessage incomingMessage = null;
                         TransportMessage transportMessage = null;
                         var transportTransaction = new TransportTransaction();
@@ -126,6 +131,11 @@
                                 s3Client,
                                 configuration,
                                 cancellationTokenSource.Token).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // shutting down
+                            return;
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
When shutting down messages fetched should not be marked as poison (happens with S3)
Early opt out when cancellation is requested.