### PR TITLE
Project cleanup

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -1,20 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.Core" version="3.*" />
+    <PackageReference Include="AWSSDK.S3" Version="3.*" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.*" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
     <PackageReference Include="NUnit" Version="3.7.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="AWSSDK.Core" version="3.*" />
-    <PackageReference Include="AWSSDK.S3" Version="3.*" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.*" />
-    <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" version="3.*" />
     <PackageReference Include="AWSSDK.S3" Version="3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.*" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-*" />

--- a/src/AcceptanceTests/SqsTransportExtensions.cs
+++ b/src/AcceptanceTests/SqsTransportExtensions.cs
@@ -7,9 +7,9 @@
 
     public static class SqsTransportExtensions
     {
-        const string RegionEnvironmentVariableName = "NServiceBus.AmazonSQS.Region";
-        const string S3BucketEnvironmentVariableName = "NServiceBus.AmazonSQS.S3Bucket";
-        const string NativeDeferralEnvironmentVariableName = "NServiceBus.AmazonSQS.NativeDeferral";
+        const string RegionEnvironmentVariableName = "NServiceBus_AmazonSQS_Region";
+        const string S3BucketEnvironmentVariableName = "NServiceBus_AmazonSQS_S3Bucket";
+        const string NativeDeferralEnvironmentVariableName = "NServiceBus_AmazonSQS_NativeDeferral";
 
         public static TransportExtensions<SqsTransport> ConfigureSqsTransport(this TransportExtensions<SqsTransport> transportConfiguration, string queueNamePrefix)
         {
@@ -26,7 +26,7 @@
                 s3Configuration.ClientFactory(CreateS3Client);
             }
 
-            var nativeDeferralRaw = EnvironmentHelper.GetEnvironmentVariable(NativeDeferralEnvironmentVariableName);        
+            var nativeDeferralRaw = EnvironmentHelper.GetEnvironmentVariable(NativeDeferralEnvironmentVariableName);
             var validValue = bool.TryParse(nativeDeferralRaw, out var nativeDeferral);
             if (validValue && nativeDeferral)
             {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/NServiceBus.AmazonSQS.sln
+++ b/src/NServiceBus.AmazonSQS.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 15.0.26430.12
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.AmazonSQS", "NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj", "{A40EBAE3-ADF8-4CD8-87DA-025BCA6BA1C2}"
 EndProject
@@ -10,6 +10,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AcceptanceTests", "AcceptanceTests\AcceptanceTests.csproj", "{E87BA318-68A7-4EEE-8817-DFC91296299B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransportTests", "TransportTests\TransportTests.csproj", "{E1E492D1-F5B2-480F-86D4-3D94E49A162D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C1C8A6A2-0462-42F0-9FC4-5401EA3DE9AF}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		..\GitVersion.yml = ..\GitVersion.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -18,4 +18,9 @@
     <PackageReference Include="Particular.Packaging" Version="*" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
-    <PackageReference Include="AWSSDK.Core" version="[3.3.17.5, 3.4)" />
     <PackageReference Include="AWSSDK.S3" Version="[3.3.9, 3.4)" />
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.2.7, 3.4)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.2.7, 3.4)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
+    <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="*" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -1,15 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>CS0419</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup>
     <Description>An Amazon SQS transport implementation for NServiceBus</Description>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
@@ -19,6 +16,6 @@
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="*" PrivateAssets="All" />
-    <None Include="..\..\GitVersion.yml" Link="GitVersion.yml" />
   </ItemGroup>
+
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,26 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
-    <DebugSymbols>True</DebugSymbols>
     <SignAssembly>true</SignAssembly>
-    <DebugType>Full</DebugType>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.Core" version="3.*" />
+    <PackageReference Include="AWSSDK.S3" Version="3.*" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
     <PackageReference Include="NUnit" Version="3.7.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="AWSSDK.Core" version="3.*" />
-    <PackageReference Include="AWSSDK.S3" Version="3.*" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.*" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
-    <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="ApprovalTests" Version="3.*" />
-    <PackageReference Include="ApprovalUtilities" Version="3.*" />
-    <PackageReference Include="PublicApiGenerator" Version="6.1.0-*" />
+    <PackageReference Include="PublicApiGenerator" Version="6.*" />
   </ItemGroup>
+
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" version="3.*" />
     <PackageReference Include="AWSSDK.S3" Version="3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />

--- a/src/TransportTests/TransportTests.csproj
+++ b/src/TransportTests/TransportTests.csproj
@@ -1,20 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NUnit" Version="3.7.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="AWSSDK.Core" version="3.*" />
-    <PackageReference Include="AWSSDK.S3" Version="3.*" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.*" />
     <ProjectReference Include="..\AcceptanceTests\AcceptanceTests.csproj" />
     <ProjectReference Include="..\NServiceBus.AmazonSQS\NServiceBus.AmazonSQS.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.Core" version="3.*" />
+    <PackageReference Include="AWSSDK.S3" Version="3.*" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-*" />
+    <PackageReference Include="NUnit" Version="3.7.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+  </ItemGroup>
+
 </Project>

--- a/src/TransportTests/TransportTests.csproj
+++ b/src/TransportTests/TransportTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)Test.snk</AssemblyOriginatorKeyFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TransportTests/TransportTests.csproj
+++ b/src/TransportTests/TransportTests.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" version="3.*" />
     <PackageReference Include="AWSSDK.S3" Version="3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />


### PR DESCRIPTION
This cleans up some things related to moving to the new project system and Particular.Packaging. I also noticed a few other misc things that seemed to be missing.

One other thing I changed here was that I didn't see a reason to be referencing AWSSDK.Core directly since both the S3 and SQS packages reference that as well.