### PR TITLE
Updates env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ To run the tests, the Access Key ID and Secret Access Key of an AWS IAM account 
 
 The transport can be configured using the following environment variables:
 
- * **NServiceBus.AmazonSQS.Region** corresponds to the [Region](https://docs.particular.net/transports/sqs/configuration-options#region) parameter. Default is no region set.
- * **NServiceBus.AmazonSQS.S3Bucket** corresponds to the [S3BucketForLargeMessages](https://docs.particular.net/transports/sqs/configuration-options#s3bucketforlargemessages) parameter. Default is no S3 bucket.
- * **NServiceBus.AmazonSQS.NativeDeferral** corresponds to the [NativeDeferral](https://docs.particular.net/transports/sqs/configuration-options#nativedeferral) parameter. Default is false.
+ * **NServiceBus_AmazonSQS_Region** corresponds to the [Region](https://docs.particular.net/transports/sqs/configuration-options#region) parameter. Default is no region set.
+ * **NServiceBus_AmazonSQS_S3Bucket** corresponds to the [S3BucketForLargeMessages](https://docs.particular.net/transports/sqs/configuration-options#s3bucketforlargemessages) parameter. Default is no S3 bucket.
+ * **NServiceBus_AmazonSQS_NativeDeferral** corresponds to the [NativeDeferral](https://docs.particular.net/transports/sqs/configuration-options#nativedeferral) parameter. Default is false.
 
 
 ### Queue Names in Acceptance Tests


### PR DESCRIPTION
As discovered environment variables containing a `.` in the name are not supported on Linux, I already created new variables on TC, tested them both on TC and locally. Changed in the code via https://github.com/Particular/NServiceBus.AmazonSQS/pull/163/commits/6c69f01e51f060fd132c8370e843f2d31f3f2034. The last thing is to update the readme.

Please review and merge.