### PR TITLE
Pump redesign

### DIFF
--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -307,7 +307,7 @@
                             new DeleteObjectRequest
                             {
                                 BucketName = configuration.S3BucketForLargeMessages,
-                                Key = configuration.S3KeyPrefix + incomingMessage.MessageId
+                                Key = transportMessage.S3BodyKey
                             },
                             token).ConfigureAwait(false);
                     }

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -116,10 +116,10 @@
 
             while (!token.IsCancellationRequested)
             {
-                var receivedMessages = await sqsClient.ReceiveMessageAsync(receiveMessagesRequest, token).ConfigureAwait(false);
-
                 try
                 {
+                    var receivedMessages = await sqsClient.ReceiveMessageAsync(receiveMessagesRequest, token).ConfigureAwait(false);
+
                     ProcessMessages(receivedMessages.Messages, concurrentReceiveOperations, token);
 
                     await Task.WhenAll(concurrentReceiveOperations).ConfigureAwait(false);
@@ -280,8 +280,7 @@
 
         async Task DeleteMessage(Message message, TransportMessage transportMessage, IncomingMessage incomingMessage, CancellationToken token)
         {
-            // should not be cancelled
-            await sqsClient.DeleteMessageAsync(queueUrl, message.ReceiptHandle, CancellationToken.None).ConfigureAwait(false);
+            await sqsClient.DeleteMessageAsync(queueUrl, message.ReceiptHandle, token).ConfigureAwait(false);
 
             if (transportMessage != null)
             {

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -155,7 +155,15 @@
             try
             {
                 await maxConcurrencySempahore.WaitAsync(token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // shutting, semaphore doesn't need to be released because it was never acquired
+                return;
+            }
 
+            try
+            {
                 IncomingMessage incomingMessage = null;
                 TransportMessage transportMessage = null;
 

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -98,11 +98,6 @@
         {
             cancellationTokenSource?.Cancel();
 
-            while (maxConcurrencySempahore.CurrentCount != maxConcurrency)
-            {
-                await Task.Delay(50, CancellationToken.None).ConfigureAwait(false);
-            }
-
             await Task.WhenAll(pumpTasks).ConfigureAwait(false);
 
             pumpTasks?.Clear();

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -299,6 +299,7 @@
             catch (ReceiptHandleIsInvalidException ex)
             {
                 Logger.Info($"Message receipt handle {message.ReceiptHandle} no longer valid.", ex);
+                return; // if another receiver fetches the data from S3
             }
 
             if (transportMessage != null)

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -90,7 +90,7 @@
 
             for (var i = 0; i < degreeOfParallelism; i++)
             {
-                pumpTasks.Add(ConsumeMessages(cancellationTokenSource.Token));
+                pumpTasks.Add(Task.Run(() => ConsumeMessages(cancellationTokenSource.Token), CancellationToken.None));
             }
         }
 

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -62,16 +62,16 @@
             cancellationTokenSource = new CancellationTokenSource();
             maxConcurrency = limitations.MaxConcurrency;
 
-            int degreeOfParallelism;
+            int numberOfPumps;
             if (maxConcurrency <= 10)
             {
-                degreeOfParallelism = 1;
+                numberOfPumps = 1;
                 numberOfMessagesToFetch = maxConcurrency;
             }
             else
             {
+                numberOfPumps = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(maxConcurrency) / numberOfMessagesToFetch));
                 numberOfMessagesToFetch = 10;
-                degreeOfParallelism = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(maxConcurrency) / numberOfMessagesToFetch));
             }
 
             receiveMessagesRequest = new ReceiveMessageRequest
@@ -86,9 +86,9 @@
             };
 
             maxConcurrencySempahore = new SemaphoreSlim(maxConcurrency);
-            pumpTasks = new List<Task>(degreeOfParallelism);
+            pumpTasks = new List<Task>(numberOfPumps);
 
-            for (var i = 0; i < degreeOfParallelism; i++)
+            for (var i = 0; i < numberOfPumps; i++)
             {
                 pumpTasks.Add(Task.Run(() => ConsumeMessages(cancellationTokenSource.Token), CancellationToken.None));
             }

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -285,7 +285,7 @@
                 return false;
             }
             // Message has expired.
-            Logger.Warn($"Discarding expired message with Id {incomingMessage.MessageId}, expired {utcNow - expiresAt} ago at {expiresAt} utc.");
+            Logger.Info($"Discarding expired message with Id {incomingMessage.MessageId}, expired {utcNow - expiresAt} ago at {expiresAt} utc.");
             return true;
         }
 

--- a/src/TransportTests/ConfigureSqsTransportInfrastructure.cs
+++ b/src/TransportTests/ConfigureSqsTransportInfrastructure.cs
@@ -21,7 +21,7 @@ public class ConfigureSqsTransportInfrastructure : IConfigureTransportInfrastruc
         return new TransportConfigurationResult
         {
             TransportInfrastructure = sqsTransport.Initialize(settings, ""),
-            PurgeInputQueueOnStartup = true
+            PurgeInputQueueOnStartup = false
         };
     }
 }


### PR DESCRIPTION
Addresses #132 and #171 

Done as part of the investigations for https://github.com/Particular/DotNetCoreLaunch/issues/114

- If the concurrency setting is below `10` it uses a degree of parallelism of 1
- If the concurrency setting is `11` or more it does a ceiling of the concurrency divided by the number of messages allowed to fetch (maximum is ten)

Examples

| Concurrency | NumberOfMessagesToFetch | DegreeOfParallelism |
|-------------|-------------------------|---------------------|
| 1-10        | 1-10                    | 1                   |
| 16          | 10                      | 2                   |
| 32          | 10                      | 4                   |
| 64          | 10                      | 7                   |
| 128         | 10                      | 13                  |

- The parallelism is still unbounded since SQS is quite scalable
- This significantly decreases the chance that messages run into visibility timeout since we are no longer over fetching tenfold
- Does not over acquire the semaphore and thus cleanly shuts down
- No longer throttles FLRs 
- Semaphore is released after deletion of message
- Slightly less allocation heavy due to reusing of transport transaction, context bag and receive task lists
- Introduces slight renaming and refactoring for better readability and maintainability

## Local run with perf test suite

### Receive Runner

#### Before

```
2017-12-12 17:30:16,481|INFO|15|Statistics|NumberOfMessages: 12,798 (#)
2017-12-12 17:30:16,481|INFO|15|Statistics|Throughput: 334.66 (msg/s)
2017-12-12 17:30:16,490|INFO|15|Statistics|NumberOfRetries: 0 (#)
2017-12-12 17:30:16,502|INFO|15|Statistics|TimeToFirstMessage: 30.07 (s)
2017-12-12 17:30:16,526|INFO|15|Statistics|PrivateMemorySize: 832,236 (kB)
2017-12-12 17:30:16,527|INFO|15|Statistics|PeakWorkingSet: 792,204 (kB)
2017-12-12 17:30:16,533|INFO|15|Statistics|PeakPagedMemorySize: 834,588 (kB)
2017-12-12 17:30:16,544|INFO|15|Statistics|PeakVirtualMemorySize: 19,398,672 (kB)
```

#### After

```
2017-12-12 17:25:11,652|INFO|21|BaseRunner|Run: Duration 00:00:57, until 12/12/2017 17:26:08
2017-12-12 17:26:08,652|INFO|29|BaseRunner|Run duration expired.
2017-12-12 17:26:08,655|INFO|29|Statistics|ReceiveFirstLastDuration: 16.55 (s)
2017-12-12 17:26:08,655|INFO|29|Statistics|NumberOfMessages: 20,940 (#)
2017-12-12 17:26:08,655|INFO|29|Statistics|Throughput: 1,265.07 (msg/s)
2017-12-12 17:26:08,656|INFO|29|Statistics|NumberOfRetries: 0 (#)
2017-12-12 17:26:08,656|INFO|29|Statistics|TimeToFirstMessage: 31.84 (s)
2017-12-12 17:26:08,663|INFO|29|Statistics|PrivateMemorySize: 830,968 (kB)
2017-12-12 17:26:08,664|INFO|29|Statistics|PeakWorkingSet: 795,192 (kB)
2017-12-12 17:26:08,664|INFO|29|Statistics|PeakPagedMemorySize: 838,528 (kB)
2017-12-12 17:26:08,664|INFO|29|Statistics|PeakVirtualMemorySize: 19,403,444 (kB)
```

