### PR TITLE
Prepare for final beta release

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.*" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.0.0-beta0012" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
     <PackageReference Include="NUnit" Version="3.7.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="[3.3.15, 3.4)" />
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.3.2, 3.4)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.3.2, 3.4)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
-    <PackageReference Include="Fody" Version="2.3.1" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="2.3.2" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.3.2, 3.4)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
-    <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="2.3.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="*" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -6,7 +6,7 @@
     <Description>An Amazon SQS transport implementation for NServiceBus</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.3.15, 3.4)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.3.16, 3.4)" />
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.3.2, 3.4)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="7.0.0-beta0012" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
     <PackageReference Include="NUnit" Version="3.7.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />

--- a/src/TransportTests/TransportTests.csproj
+++ b/src/TransportTests/TransportTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="AWSSDK.S3" Version="3.*" />
     <PackageReference Include="AWSSDK.SQS" Version="3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.0.0-beta0012" />
     <PackageReference Include="NUnit" Version="3.7.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>


### PR DESCRIPTION
@Particular/aws-maintainers There are still errors related to different versions of AWS S3 analyzer assemblies because the test projects are still using wildcards and are pulling in a newer version of the package.

There are a couple ways to solve this. If using a newer client in the tests is desired, the package references could be set up to exclude the analyzers for the test projects.