### PR TITLE
Update Fody to 2.4.5

### DIFF
--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.3.2, 3.4)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-rc0001, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
-    <PackageReference Include="Fody" Version="2.4.4" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="2.4.5" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.7" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />


### PR DESCRIPTION
This version of Fody fixes the problem where the wrong version of Obsolete.Fody 
 can be chosen, causing build failures: https://github.com/Fody/Obsolete/issues/21