### PR TITLE
Better error logging when message sends fail

### DIFF
--- a/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
+++ b/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
@@ -1,9 +1,5 @@
 ﻿namespace NServiceBus.Transports.SQS
 {
-    using System;
-    using System.IO;
-    using System.Linq;
-    using System.Threading.Tasks;
     using Amazon.S3;
     using Amazon.S3.Model;
     using Amazon.SQS;
@@ -14,6 +10,10 @@
     using Logging;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
     using Transport;
 
     class MessageDispatcher : IDispatchMessages
@@ -151,6 +151,11 @@
                 var queueName = destination.Substring(0, destination.Length - TransportConfiguration.DelayedDeliveryQueueSuffix.Length);
 
                 throw new QueueDoesNotExistException($"Destination '{queueName}' doesn't support delayed messages longer than {TimeSpan.FromSeconds(configuration.DelayedDeliveryQueueDelayTime)}. To enable support for longer delays, call '.UseTransport<SqsTransport>().UnrestrictedDelayedDelivery()' on the '{queueName}' endpoint.", e);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Error while sending message, with MessageId '{messageId}', to '{destination}'", ex);
+                throw;
             }
         }
 


### PR DESCRIPTION
Alternative approach to #228 

This is a proposed fix for #227. Actually raised as a maintenance fix to `develop`, if we want we can treat this as `hotfix` and re-target to `master` instead.

Another approach could be to append a continuation to the `Task` returned by `Dispatch` https://github.com/Particular/NServiceBus.AmazonSQS/blob/efb1869ff9a6a9b1ff30b8fb7dba4a0ad9962af2/src/NServiceBus.AmazonSQS/MessageDispatcher.cs#L42 and log in the continuation. I personally find the approach used in this PR leaner and cleaner.

I vote to close #228 in favor of this one.