### PR TITLE
Enable compatibility mode to receive V1 messages

### DIFF
--- a/src/AcceptanceTests/Sending_in_compatibility_mode.cs
+++ b/src/AcceptanceTests/Sending_in_compatibility_mode.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class Sending_in_compatibility_mode : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_message()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(session => session.Send(new Message())))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.Received)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Received { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    builder.ConfigureTransport().Routing().RouteToEndpoint(typeof(Message), typeof(Receiver));
+                    builder.ConfigureSqsTransport().EnableV1CompatibilityMode();
+                });
+            }
+
+            public class Handler : IHandleMessages<Reply>
+            {
+                public Context Context { get; set; }
+                
+                public Task Handle(Reply message, IMessageHandlerContext context)
+                {
+                    Context.Received = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<Message>
+            {
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new Reply());
+                }
+            }
+
+        }
+
+        public class Message : ICommand
+        {
+        }
+        
+        public class Reply : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -1,26 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Description>An Amazon SQS transport implementation for NServiceBus</Description>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="[3.3.16, 3.4)" />
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.3.2, 3.4)" />
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[10.0.1, 11.0.0)" />
-    <PackageReference Include="Fody" Version="2.4.5" PrivateAssets="All" />
-    <PackageReference Include="Obsolete.Fody" Version="4.3.7" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="3.1.3" PrivateAssets="All" />
+    <PackageReference Include="Obsolete.Fody" Version="4.4.1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
   </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.AmazonSQS/ReducedPayloadContractResolver.cs
+++ b/src/NServiceBus.AmazonSQS/ReducedPayloadContractResolver.cs
@@ -3,6 +3,7 @@
     using System.Reflection;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
+    
     class ReducedPayloadContractResolver : DefaultContractResolver
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
@@ -10,8 +11,8 @@
             var property = base.CreateProperty(member, memberSerialization);
 
             property.ShouldSerialize = instance => property.DeclaringType != typeof(TransportMessage) || 
-                                                   (property.PropertyName != nameof(TransportMessage.TimeToBeReceived) && 
-                                                    property.PropertyName != nameof(TransportMessage.ReplyToAddress));
+                                                   property.PropertyName != nameof(TransportMessage.TimeToBeReceived) && 
+                                                   property.PropertyName != nameof(TransportMessage.ReplyToAddress);
 
             return property;
         }

--- a/src/NServiceBus.AmazonSQS/TransportMessage.cs
+++ b/src/NServiceBus.AmazonSQS/TransportMessage.cs
@@ -52,16 +52,22 @@
             }
         }
 
-        public string ReplyToAddress
+        public Address? ReplyToAddress
         {
-            get => Headers.ContainsKey(NServiceBus.Headers.ReplyToAddress) ? Headers[NServiceBus.Headers.ReplyToAddress] : null;
+            get => Headers.ContainsKey(NServiceBus.Headers.ReplyToAddress) ? new Address { Queue = Headers[NServiceBus.Headers.ReplyToAddress] } : (Address?)null;
             set
             {
-                if (value != null)
+                if (!string.IsNullOrWhiteSpace(value?.Queue))
                 {
-                    Headers[NServiceBus.Headers.ReplyToAddress] = value;
+                    Headers[NServiceBus.Headers.ReplyToAddress] = value.Value.Queue;
                 }
             }
+        }
+
+        public struct Address
+        {
+            public string Queue { get; set; }
+            public string Machine { get; set; }
         }
     }
 }

--- a/src/Tests/MessageDispatcherTests.cs
+++ b/src/Tests/MessageDispatcherTests.cs
@@ -34,8 +34,8 @@
                     new OutgoingMessage("1234", new Dictionary<string, string>
                     {
                         {TransportHeaders.TimeToBeReceived, expectedTtbr.ToString()},
-                        {Headers.ReplyToAddress, expectedReplyToAddress}                        
-                    }, Encoding.Default.GetBytes("{}")), 
+                        {Headers.ReplyToAddress, expectedReplyToAddress}
+                    }, Encoding.Default.GetBytes("{}")),
                     new UnicastAddressTag("address")));
 
             var transportTransaction = new TransportTransaction();
@@ -46,15 +46,16 @@
             Assert.IsNotEmpty(mockSqsClient.RequestsSent, "No requests sent");
             var request = mockSqsClient.RequestsSent.First();
 
-            IDictionary<string,JToken> bodyJson = JObject.Parse(request.MessageBody);
+            IDictionary<string, JToken> bodyJson = JObject.Parse(request.MessageBody);
 
             Assert.IsTrue(bodyJson.ContainsKey("TimeToBeReceived"), "TimeToBeReceived not serialized");
             Assert.AreEqual(expectedTtbr.ToString(), bodyJson["TimeToBeReceived"].Value<string>(), "Expected TTBR mismatch");
 
             Assert.IsTrue(bodyJson.ContainsKey("ReplyToAddress"), "ReplyToAddress not serialized");
-            Assert.AreEqual(expectedReplyToAddress, bodyJson["ReplyToAddress"].Value<string>(), "Expected ReplyToAddress mismatch");
+            Assert.IsTrue(bodyJson["ReplyToAddress"].HasValues, "ReplyToAddress is not an object");
+            Assert.IsTrue(bodyJson["ReplyToAddress"].Value<IDictionary<string, JToken>>().ContainsKey("Queue"), "ReplyToAddress does not have a Queue value");
+            Assert.AreEqual(expectedReplyToAddress, bodyJson["ReplyToAddress"].Value<JObject>()["Queue"].Value<string>(), "Expected ReplyToAddress mismatch");
         }
-
 
         [Test]
         public async Task Does_not_send_extra_properties_in_payload_by_default()

--- a/src/Tests/TransportMessageTests.cs
+++ b/src/Tests/TransportMessageTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using DeliveryConstraints;
+    using Newtonsoft.Json;
     using NUnit.Framework;
     using Performance.TimeToBeReceived;
     using Transport;
@@ -84,7 +85,7 @@
 
             var transportMessage = new TransportMessage(outgoingMessage, new List<DeliveryConstraint>());
 
-            Assert.AreEqual(expectedReplyToAddress, transportMessage.ReplyToAddress, "ReplyToAddress is not the expected value");
+            Assert.AreEqual(expectedReplyToAddress, transportMessage.ReplyToAddress.Value.Queue, "ReplyToAddress is not the expected value");
         }
 
         [Test]
@@ -103,7 +104,7 @@
             var transportMessage = new TransportMessage
             {
                 Headers = new Dictionary<string, string>(),
-                ReplyToAddress = expectedReplyToAddress
+                ReplyToAddress = new TransportMessage.Address { Queue = expectedReplyToAddress }
             };
 
             Assert.IsTrue(transportMessage.Headers.ContainsKey(Headers.ReplyToAddress), "ReplyToAddress header is missing");
@@ -120,6 +121,54 @@
             };
 
             Assert.IsFalse(transportMessage.Headers.ContainsKey(Headers.ReplyToAddress), "ReplyToAddress header was created");
+        }
+
+        [Test]
+        public void Can_be_built_from_serialized_v1_message()
+        {
+            var json = JsonConvert.SerializeObject(new
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    {Headers.MessageId, Guid.Empty.ToString()}
+                },
+                Body = "empty message",
+                S3BodyKey = (string)null,
+                TimeToBeReceived = expectedTtbr,
+                ReplyToAddress = new
+                {
+                    Queue = expectedReplyToAddress,
+                    Machine = Environment.MachineName
+                }
+            });
+
+            var transportMessage = JsonConvert.DeserializeObject<TransportMessage>(json);
+
+            Assert.IsTrue(transportMessage.Headers.ContainsKey(TransportHeaders.TimeToBeReceived), "TimeToBeReceived header is missing");
+            Assert.AreEqual(expectedTtbr.ToString(), transportMessage.Headers[TransportHeaders.TimeToBeReceived], "TimeToBeReceived header does not match expected value.");
+            Assert.IsTrue(transportMessage.Headers.ContainsKey(Headers.ReplyToAddress), "ReplyToAddress header is missing");
+            Assert.AreEqual(expectedReplyToAddress, transportMessage.Headers[Headers.ReplyToAddress], "ReplyToAddress header does not match expected value.");
+        }
+        
+        [Test]
+        public void Can_be_built_from_serialized_message()
+        {
+            var json = JsonConvert.SerializeObject(new
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    {Headers.MessageId, Guid.Empty.ToString()}
+                },
+                Body = "empty message",
+                S3BodyKey = (string)null,
+            });
+
+            var transportMessage = JsonConvert.DeserializeObject<TransportMessage>(json);
+
+            Assert.IsFalse(transportMessage.Headers.ContainsKey(TransportHeaders.TimeToBeReceived), "TimeToBeReceived header was found");
+            Assert.AreEqual(TimeSpan.MaxValue.ToString(), transportMessage.TimeToBeReceived, "TimeToBeReceived does not match expected value.");
+            Assert.IsFalse(transportMessage.Headers.ContainsKey(Headers.ReplyToAddress), "ReplyToAddress header was found");
+            Assert.IsNull(transportMessage.ReplyToAddress, "ReplyToAddress was not null.");
         }
     }
 }


### PR DESCRIPTION
The compatibility mode enables sending of v1 compatible messages but not receiving of those. This fix enables receiving of V1 messages as well. 