### PR TITLE
Propagate NSB message ID to SQS message attributes

### DIFF
--- a/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
+++ b/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
@@ -135,7 +135,17 @@
                     var queueUrl = await queueUrlCache.GetQueueUrl(QueueNameHelper.GetSqsQueueName(destination, configuration))
                         .ConfigureAwait(false);
 
-                    sendMessageRequest = new SendMessageRequest(queueUrl, message);
+                    sendMessageRequest = new SendMessageRequest(queueUrl, message)
+                    {
+                        MessageAttributes =
+                        {
+                            [Headers.MessageId] = new MessageAttributeValue
+                            {
+                                StringValue = messageId,
+                                DataType = "String"
+                            }
+                        }
+                    };
 
                     if (delaySeconds > 0)
                     {

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -321,12 +321,7 @@
                     isPoisonMessage = true;
                 }
 
-                if (messageBody == null || transportMessage == null)
-                {
-                    isPoisonMessage = true;
-                }
-
-                if (isPoisonMessage)
+                if (isPoisonMessage || messageBody == null || transportMessage == null)
                 {
                     var logMessage = $"Treating message with {messageId} as a poison message. Moving to error queue.";
                     

--- a/src/NServiceBus.AmazonSQS/MessagePump.cs
+++ b/src/NServiceBus.AmazonSQS/MessagePump.cs
@@ -462,14 +462,12 @@
                 {
                     QueueUrl = errorQueueUrl,
                     MessageBody = message.Body,
-                    MessageAttributes = new Dictionary<string, MessageAttributeValue>
+                    MessageAttributes =
                     {
+                        [Headers.MessageId] = new MessageAttributeValue
                         {
-                            Headers.MessageId, new MessageAttributeValue
-                            {
-                                StringValue = messageId,
-                                DataType = "String"
-                            }
+                            StringValue = messageId,
+                            DataType = "String"
                         }
                     }
                 }, CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
Closes #258 

We decided to propagate the Headers.MessageId value every time. There is no way to opt-in or opt-out from that behavior. We decided against opt-in because we thought in cases of poison messages you'd wish you had it enabled. We decided against opt-out even though you can only use up to 10 message attributes and they contribute to the overall message size because we think the information is always valuable. Plus us reserving one of these 10 message attributes should not be the tipping point at all. If it turns out to be for some reason we can always ship a new minor that allows to opt-out. Right now the additional configuration APIs and code complexity seem unnecessary.
