### PR TITLE
Avoid header manipulation being visible between processing attempts

### DIFF
--- a/src/AcceptanceTests/AcceptanceTests.csproj
+++ b/src/AcceptanceTests/AcceptanceTests.csproj
@@ -16,4 +16,11 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Remove once core ATTs have been fixed, see https://github.com/Particular/NServiceBus/pull/5329 -->
+    <Compile Remove="\**\MessageId\When_message_has_empty_id_header.cs" />
+    <Compile Remove="\**\Pipeline\When_sending_to_another_endpoint.cs" />
+    <Compile Remove="\**\Recoverability\When_message_fails_retries.cs" />
+</ItemGroup>
 </Project>

--- a/src/NServiceBus.AmazonSQS/FixedSizeDictionaryPool.cs
+++ b/src/NServiceBus.AmazonSQS/FixedSizeDictionaryPool.cs
@@ -1,0 +1,61 @@
+namespace NServiceBus.Transports.SQS
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+
+    class FixedSizeDictionaryPool
+    {
+        ConcurrentBag<Dictionary<string, string>> pool = new ConcurrentBag<Dictionary<string, string>>();
+
+        public Lease Rent(Dictionary<string, string> fillWith = null)
+        {
+            if (!pool.TryTake(out var rent))
+            {
+                rent = new Dictionary<string, string>(16);
+            }
+            else
+            {
+                rent.Clear();
+            }
+
+            if (fillWith != null)
+            {
+                foreach (var kvp in fillWith)
+                {
+                    rent.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            return new Lease(rent, this);
+        }
+
+        void Return(Dictionary<string, string> dictionary)
+        {
+            dictionary.Clear();
+            pool.Add(dictionary);
+        }
+
+        public struct Lease : IDisposable
+        {
+            Dictionary<string, string> rented;
+            FixedSizeDictionaryPool pool;
+
+            public Lease(Dictionary<string, string> rented, FixedSizeDictionaryPool pool)
+            {
+                this.pool = pool;
+                this.rented = rented;
+            }
+
+            public void Dispose()
+            {
+                pool.Return(rented);
+            }
+
+            public static implicit operator Dictionary<string, string>(Lease lease)
+            {
+                return lease.rented;
+            }
+        }
+    }
+}

--- a/src/Tests/FixedSizeDictionaryPoolTests.cs
+++ b/src/Tests/FixedSizeDictionaryPoolTests.cs
@@ -1,0 +1,88 @@
+namespace Tests
+{
+    using System.Collections.Generic;
+    using NServiceBus.Transports.SQS;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class FixedSizeDictionaryPoolTests
+    {
+        [Test]
+        public void Reuses_dictionaries()
+        {
+            var pool = new FixedSizeDictionaryPool();
+            Dictionary<string, string> firstAcquired, secondAcquired;
+
+            using (var dictionary = pool.Rent())
+            {
+                firstAcquired = dictionary;
+
+                firstAcquired.Add("Something", "OfInterest");
+            }
+            using (var dictionary = pool.Rent())
+            {
+                secondAcquired = dictionary;
+                secondAcquired.Add("Something", "OfInterest");
+            }
+
+            Assert.AreSame(firstAcquired, secondAcquired);
+            Assert.That(firstAcquired, Is.Empty);
+            Assert.That(secondAcquired, Is.Empty);
+        }
+
+        [Test]
+        public void Prevents_evilness()
+        {
+            var pool = new FixedSizeDictionaryPool();
+            Dictionary<string, string> firstAcquired;
+
+            using (var dictionary = pool.Rent())
+            {
+                firstAcquired = dictionary;
+
+                firstAcquired.Add("Something", "OfInterest");
+            }
+
+            firstAcquired.Add("Something", "OfInterest");
+
+            using (var dictionary = pool.Rent())
+            {
+                Assert.That((Dictionary<string, string>)dictionary, Is.Empty);
+            }
+        }
+
+        [Test]
+        public void ExpandsCapacityAsNeeded()
+        {
+            var pool = new FixedSizeDictionaryPool();
+            Dictionary<string, string> firstAcquired, secondAcquired, thirdAcquired;
+
+            using (var dictionary1 = pool.Rent())
+            using (var dictionary2 = pool.Rent())
+            using (var dictionary3 = pool.Rent())
+            {
+                firstAcquired = dictionary1;
+                secondAcquired = dictionary2;
+                thirdAcquired = dictionary3;
+            }
+
+            Assert.AreNotSame(firstAcquired, secondAcquired);
+            Assert.AreNotSame(firstAcquired, thirdAcquired);
+            Assert.AreNotSame(secondAcquired, thirdAcquired);
+        }
+
+        [Test]
+        public void Prefills()
+        {
+            var pool = new FixedSizeDictionaryPool();
+            var template = new Dictionary<string, string> { { "Something", "OfInterest"} };
+
+            using (var dictionary = pool.Rent(template))
+            {
+                Dictionary<string, string> acquired = dictionary;
+
+                Assert.AreEqual(template, acquired);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #248, #249, #250 

The core seam does not prevent header manipulations from being leaked back into the transport. The mutable dictionary exposed on the message context practically invites for that problem to happen. Instead of just creating a new dictionary every time a simple fixed size dictionary pool is used that grows on demand. This is more efficient as shown in https://github.com/Particular/NServiceBus.AmazonSQS/issues/248#issuecomment-463616074

The pool grows its capacity over time up to the concurrency of the pump. The pool is not shared between the pumps although technically it could be

This exposes us to the following risk

If someone assigns the header dictionary of an incoming message to a state holder that outlives the message handling pipeline that dictionary will get cleared ones the message is processed by the transport. Users doing that have to copy the headers. This is an acceptable design constraints given that you cannot assume that message based information is going to stay longer than the pipeline (afaik the core even enforces that by floating the state into the handler and pipeline methods.

I verified that with @SzymonPobiega wearing both his "knowledgeable in core" and "keeping the lights on" hat and we agree that it is an acceptable tradeoff because paying for the dictionary allocation every time is not worth it.

Should someone buffer outgoing messages and send them out later those users would not be affected because outgoing messages have dedicated header copies (exception when forwarding but that happens as part of the incoming message handling pipeline)