### PR TITLE
Bump min required AWSSDK.Core version to 3.3.28.1 to avoid ReceiveMessagesAsync hanging forever on connection loss

### DIFF
--- a/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.AmazonSQS.AcceptanceTests/NServiceBus.AmazonSQS.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NServiceBus" Version="6.*" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="6.*" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="AWSSDK.Core" version="3.3.17.5" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.28.1" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.9" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.2.7" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />

--- a/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
+++ b/src/NServiceBus.AmazonSQS.Tests/NServiceBus.AmazonSQS.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NServiceBus" Version="6.*" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.17.5" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.28.1" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.9" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.2.7" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />

--- a/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
+++ b/src/NServiceBus.AmazonSQS.TransportTests/NServiceBus.AmazonSQS.TransportTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NServiceBus" Version="6.*" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="6.*" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="AWSSDK.Core" version="3.3.17.5" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.28.1" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.9" />
     <PackageReference Include="AWSSDK.SQS" Version="3.3.2.7" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />

--- a/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
+++ b/src/NServiceBus.AmazonSQS/NServiceBus.AmazonSQS.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NServiceBus" Version="[6.0.0, 7.0.0)" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="[11.0.1, 12.0.0)" />
-    <PackageReference Include="AWSSDK.Core" Version="[3.3.17.5, 3.4)" />
+    <PackageReference Include="AWSSDK.Core" Version="[3.3.28.1, 3.4)" />
     <PackageReference Include="AWSSDK.S3" Version="[3.3.9, 3.4)" />
     <PackageReference Include="AWSSDK.SQS" Version="[3.3.2.7, 3.4)" />
     <PackageReference Include="Particular.Packaging" Version="0.2.1" PrivateAssets="All" />


### PR DESCRIPTION
Fixes #296

## Who's affected

All Customers using AWSSDK.Core version lower than 3.3.28.1

## Symptoms

When a connectivity failure occurs the AWSSDK.Core might indefinitely hang in `ReceiveMessagesAsync` and thus no more messages will be consumed until the endpoint is restarted

## Workaround

- Restart the endpoint as a temporary workaround
- Bump manually the minimum required version of AWSSDK.Core  to 3.3.28.1 or higher

