### PR TITLE
Invalid characters in MessageId cause InvalidBatchEntryIdException

### DIFF
--- a/src/NServiceBus.AmazonSQS/Batcher.cs
+++ b/src/NServiceBus.AmazonSQS/Batcher.cs
@@ -32,7 +32,8 @@ namespace NServiceBus.Transports.SQS
                     }
 
                     // we don't have to recheck payload size here because the support layer checks that a request can always fit 256 KB size limit
-                    currentDestinationBatches.Add(message.MessageId, message);
+                    // we can't take MessageId because batch request ID can only contain alphanumeric characters, hyphen and underscores, message id could be overloaded
+                    currentDestinationBatches.Add(Guid.NewGuid().ToString(), message);
 
                     var currentCount = currentDestinationBatches.Count;
                     if (currentCount != 0 && currentCount % TransportConfiguration.MaximumItemsInBatch == 0)

--- a/src/NServiceBus.AmazonSQS/PreparedMessageExtensions.cs
+++ b/src/NServiceBus.AmazonSQS/PreparedMessageExtensions.cs
@@ -17,9 +17,9 @@ namespace NServiceBus.Transports.SQS
             };
         }
 
-        static SendMessageBatchRequestEntry ToBatchEntry(this PreparedMessage message)
+        static SendMessageBatchRequestEntry ToBatchEntry(this PreparedMessage message, string batchEntryId)
         {
-            return new SendMessageBatchRequestEntry(message.MessageId, message.Body)
+            return new SendMessageBatchRequestEntry(batchEntryId, message.Body)
             {
                 MessageAttributes = message.MessageAttributes,
                 MessageGroupId = message.MessageGroupId,
@@ -31,7 +31,12 @@ namespace NServiceBus.Transports.SQS
         public static BatchEntry ToBatchRequest(this PreparedMessage message, Dictionary<string, PreparedMessage> batchEntries)
         {
             var preparedMessagesBydId = batchEntries.ToDictionary(x => x.Key, x => x.Value);
-            var batchRequestEntries = new List<SendMessageBatchRequestEntry>(preparedMessagesBydId.Select(x => x.Value.ToBatchEntry()));
+
+            var batchRequestEntries = new List<SendMessageBatchRequestEntry>();
+            foreach (var kvp in preparedMessagesBydId)
+            {
+                batchRequestEntries.Add(kvp.Value.ToBatchEntry(kvp.Key));
+            }
 
             return new BatchEntry
             {

--- a/src/Tests/BatcherTests.cs
+++ b/src/Tests/BatcherTests.cs
@@ -38,7 +38,7 @@ namespace Tests
             Assert.AreEqual("https://destination2", batches.ElementAt(1).BatchRequest.QueueUrl);
             Assert.AreEqual("https://destination3", batches.ElementAt(2).BatchRequest.QueueUrl);
         }
-        
+
         [Test]
         public void BatchPerDestination_case_sensitive()
         {
@@ -221,7 +221,7 @@ namespace Tests
         }
 
         [Test]
-        public void AppliesIdentity()
+        public void DoesntUseMessageIdentityAsBatchIdentity()
         {
             var messageId = Guid.NewGuid().ToString();
 
@@ -232,7 +232,7 @@ namespace Tests
 
             var batches = Batcher.Batch(preparedMessages);
 
-            Assert.AreEqual(messageId, batches.Single().BatchRequest.Entries.Single().Id);
+            Assert.AreNotEqual(messageId, batches.Single().BatchRequest.Entries.Single().Id);
         }
 
         [Test]

--- a/src/Tests/MessageDispatcherTests.cs
+++ b/src/Tests/MessageDispatcherTests.cs
@@ -261,7 +261,8 @@
 
             mockSqsClient.BatchRequestResponse = req =>
             {
-                if (req.Entries.Any(x => x.Id == firstMessageIdThatWillFail))
+                var firstMessageMatch = req.Entries.SingleOrDefault(x => x.MessageAttributes[Headers.MessageId].StringValue == firstMessageIdThatWillFail);
+                if (firstMessageMatch != null)
                 {
                     return new SendMessageBatchResponse
                     {
@@ -269,14 +270,15 @@
                         {
                             new BatchResultErrorEntry
                             {
-                                Id = firstMessageIdThatWillFail,
+                                Id = firstMessageMatch.Id,
                                 Message = "You know why"
                             }
                         }
                     };
                 }
 
-                if (req.Entries.Any(x => x.Id == secondMessageIdThatWillFail))
+                var secondMessageMatch = req.Entries.SingleOrDefault(x => x.MessageAttributes[Headers.MessageId].StringValue == secondMessageIdThatWillFail);
+                if (secondMessageMatch != null)
                 {
                     return new SendMessageBatchResponse
                     {
@@ -284,7 +286,7 @@
                         {
                             new BatchResultErrorEntry
                             {
-                                Id = secondMessageIdThatWillFail,
+                                Id = secondMessageMatch.Id,
                                 Message = "You know why"
                             }
                         }
@@ -325,8 +327,8 @@
             Assert.AreEqual(secondMessageIdThatWillFail, mockSqsClient.RequestsSent.ElementAt(1).MessageAttributes[Headers.MessageId].StringValue);
 
             Assert.AreEqual(2, mockSqsClient.BatchRequestsSent.Count);
-            CollectionAssert.AreEquivalent(new[] { firstMessageIdThatWillFail, firstMessageThatWillBeSuccessful }, mockSqsClient.BatchRequestsSent.ElementAt(0).Entries.Select(x => x.Id));
-            CollectionAssert.AreEquivalent(new[] { secondMessageIdThatWillFail, secondMessageThatWillBeSuccessful }, mockSqsClient.BatchRequestsSent.ElementAt(1).Entries.Select(x => x.Id));
+            CollectionAssert.AreEquivalent(new[] { firstMessageIdThatWillFail, firstMessageThatWillBeSuccessful }, mockSqsClient.BatchRequestsSent.ElementAt(0).Entries.Select(x => x.MessageAttributes[Headers.MessageId].StringValue));
+            CollectionAssert.AreEquivalent(new[] { secondMessageIdThatWillFail, secondMessageThatWillBeSuccessful }, mockSqsClient.BatchRequestsSent.ElementAt(1).Entries.Select(x => x.MessageAttributes[Headers.MessageId].StringValue));
         }
     }
 }


### PR DESCRIPTION
## Who's affected

Anyone that is using a [custom message ID](https://docs.particular.net/nservicebus/messaging/message-identity
) that contains non-alphanumeric characters

## Symptoms

When a custom message ID is set that contains non-alphanumeric characters the following exception will be thrown

```
Amazon.SQS.Model.InvalidBatchEntryIdException: A batch entry id can only contain alphanumeric characters, hyphens and underscores. It can be at most 80 letters long. ---> Amazon.Runtime.Internal.HttpErrorResponseException: The remote server returned an error: (400) Bad Request. ---> System.Net.WebException: The remote server returned an error: (400) Bad Request.
```

## Workaround

Set the message ID to alphanumeric characters, hyphens and underscores only with a maximum length of of 80 characters

More investigation details https://github.com/Particular/ServiceControl/issues/1636