### PR TITLE
WIP Added support to ServerSideEncryptionMethod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ installer/ServiceControl-cache
 *.userosscache
 *.sln.docstates
 .vs/
+.vscode/
 
 # mac temp file ignore
 .DS_Store

--- a/src/NServiceBus.AmazonSQS/Configure/S3Settings.cs
+++ b/src/NServiceBus.AmazonSQS/Configure/S3Settings.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
     /// </summary>
     public class S3Settings : ExposeSettings
     {
-        internal S3Settings(SettingsHolder settings, string bucketForLargeMessages, string keyPrefix, string encryption) : base(settings)
+        internal S3Settings(SettingsHolder settings, string bucketForLargeMessages, string keyPrefix, string encryptionMethod) : base(settings)
         {
             Guard.AgainstNull(nameof(bucketForLargeMessages), bucketForLargeMessages);
             Guard.AgainstNullAndEmpty(nameof(keyPrefix), keyPrefix);
@@ -55,7 +55,7 @@ namespace NServiceBus
 
             this.GetSettings().Set(SettingsKeys.S3BucketForLargeMessages, bucketForLargeMessages);
             this.GetSettings().Set(SettingsKeys.S3KeyPrefix, keyPrefix);
-            this.GetSettings().Set(SettingsKeys.S3Encryption, encryption);
+            this.GetSettings().Set(SettingsKeys.S3EncryptionMethod, encryptionMethod);
         }
 
         /// <summary>

--- a/src/NServiceBus.AmazonSQS/Configure/S3Settings.cs
+++ b/src/NServiceBus.AmazonSQS/Configure/S3Settings.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
     /// </summary>
     public class S3Settings : ExposeSettings
     {
-        internal S3Settings(SettingsHolder settings, string bucketForLargeMessages, string keyPrefix) : base(settings)
+        internal S3Settings(SettingsHolder settings, string bucketForLargeMessages, string keyPrefix, string encryption) : base(settings)
         {
             Guard.AgainstNull(nameof(bucketForLargeMessages), bucketForLargeMessages);
             Guard.AgainstNullAndEmpty(nameof(keyPrefix), keyPrefix);
@@ -55,6 +55,7 @@ namespace NServiceBus
 
             this.GetSettings().Set(SettingsKeys.S3BucketForLargeMessages, bucketForLargeMessages);
             this.GetSettings().Set(SettingsKeys.S3KeyPrefix, keyPrefix);
+            this.GetSettings().Set(SettingsKeys.S3Encryption, encryption);
         }
 
         /// <summary>

--- a/src/NServiceBus.AmazonSQS/Configure/SettingsKeys.cs
+++ b/src/NServiceBus.AmazonSQS/Configure/SettingsKeys.cs
@@ -7,6 +7,7 @@
         public const string MaxTimeToLive = Prefix + nameof(MaxTimeToLive);
         public const string S3BucketForLargeMessages = Prefix + nameof(S3BucketForLargeMessages);
         public const string S3KeyPrefix = Prefix + nameof(S3KeyPrefix);
+        public const string S3EncryptionMethod = Prefix + nameof(S3EncryptionMethod);
         public const string S3ClientFactory = Prefix + nameof(S3ClientFactory);
         public const string QueueNamePrefix = Prefix + nameof(QueueNamePrefix);
         public const string CredentialSource = Prefix + nameof(CredentialSource);

--- a/src/NServiceBus.AmazonSQS/Configure/SqsTransportSettings.cs
+++ b/src/NServiceBus.AmazonSQS/Configure/SqsTransportSettings.cs
@@ -60,10 +60,11 @@
         /// <param name="transportExtensions">The transport extensions.</param>
         /// <param name="bucketForLargeMessages">The name of the S3 Bucket.</param>
         /// <param name="keyPrefix">The path within the specified S3 Bucket to store large message bodies.</param>
-        public static S3Settings S3(this TransportExtensions<SqsTransport> transportExtensions, string bucketForLargeMessages, string keyPrefix)
+        /// <param name="encryption">S3 storage encryption algorithm.</param>
+        public static S3Settings S3(this TransportExtensions<SqsTransport> transportExtensions, string bucketForLargeMessages, string keyPrefix, string encryption = null)
         {
             Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
-            return new S3Settings(transportExtensions.GetSettings(), bucketForLargeMessages, keyPrefix);
+            return new S3Settings(transportExtensions.GetSettings(), bucketForLargeMessages, keyPrefix, encryption);
         }
 
         /// <summary>

--- a/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
+++ b/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
@@ -223,7 +223,8 @@
                     {
                         BucketName = configuration.S3BucketForLargeMessages,
                         InputStream = bodyStream,
-                        Key = key
+                        Key = key,
+                        ServerSideEncryptionMethod = configuration.S3EncryptionMethod
                     }).ConfigureAwait(false);
                 }
 

--- a/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
+++ b/src/NServiceBus.AmazonSQS/MessageDispatcher.cs
@@ -219,13 +219,19 @@
 
                 using (var bodyStream = new MemoryStream(transportOperation.Message.Body))
                 {
-                    await s3Client.PutObjectAsync(new PutObjectRequest
+                    var request = new PutObjectRequest
                     {
                         BucketName = configuration.S3BucketForLargeMessages,
                         InputStream = bodyStream,
-                        Key = key,
-                        ServerSideEncryptionMethod = configuration.S3EncryptionMethod
-                    }).ConfigureAwait(false);
+                        Key = key
+                    };
+
+                    if(configuration.S3EncryptionMethod != null)
+                    {
+                        request.ServerSideEncryptionMethod = configuration.S3EncryptionMethod;
+                    }
+
+                    await s3Client.PutObjectAsync(request).ConfigureAwait(false);
                 }
 
                 sqsTransportMessage.S3BodyKey = key;

--- a/src/NServiceBus.AmazonSQS/TransportConfiguration.cs
+++ b/src/NServiceBus.AmazonSQS/TransportConfiguration.cs
@@ -50,6 +50,18 @@
             }
         }
 
+        public ServerSideEncryptionMethod S3EncryptionMethod
+        {
+            get
+            {
+                if (s3EncryptionMethod == null)
+                {
+                    s3EncryptionMethod = new ServerSideEncryptionMethod(settings.GetOrDefault<string>(SettingsKeys.S3EncryptionMethod));
+                }
+                return s3EncryptionMethod;
+            }
+        }
+
         public string S3BucketForLargeMessages
         {
             get
@@ -152,6 +164,7 @@
         bool? preTruncateQueueNames;
         bool? useV1CompatiblePayload;
         int? queueDelayTime;
+        ServerSideEncryptionMethod s3EncryptionMethod;
         Func<IAmazonS3> s3ClientFactory;
         Func<IAmazonSQS> sqsClientFactory;
     }

--- a/src/NServiceBus.AmazonSQS/TransportConfiguration.cs
+++ b/src/NServiceBus.AmazonSQS/TransportConfiguration.cs
@@ -54,7 +54,7 @@
         {
             get
             {
-                if (s3EncryptionMethod == null)
+                if (s3EncryptionMethod == null && !string.IsNullOrEmpty(SettingsKeys.S3EncryptionMethod))
                 {
                     s3EncryptionMethod = new ServerSideEncryptionMethod(settings.GetOrDefault<string>(SettingsKeys.S3EncryptionMethod));
                 }


### PR DESCRIPTION
Hi, 
we are using Sqs Transport combined with S3 for large messages. Our S3 storage is a private storage with encryption.
Looking the code I noticed that the implementation inside this package doesn't support that scenario, so I opened a PR.

My idea is to allow the user to specify the encryption method into the settings and use it into the `PutObjectRequest`.

Take a look and tell me if it does make sense to you (maybe you didn't implement it for a specific reason I don't know).

Thanks
