### PR TITLE
Add TransportConfiguration.MessageAttributesReservedSize

### DIFF
--- a/src/NServiceBus.AmazonSQS/TransportConfiguration.cs
+++ b/src/NServiceBus.AmazonSQS/TransportConfiguration.cs
@@ -140,7 +140,11 @@
         public const string DelayedDeliveryQueueSuffix = "-delay.fifo";
         public static readonly int AwsMaximumQueueDelayTime = (int)TimeSpan.FromMinutes(15).TotalSeconds;
         public static readonly TimeSpan DelayedDeliveryQueueMessageRetentionPeriod = TimeSpan.FromDays(4);
-        public const int MaximumMessageSize = 256 * 1024;
+
+        // Attributes are included in 256 KB limit https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html
+        // reserve size to allow NServiceBus.MessageId attribute
+        public const int MessageAttributesReservedSize = 128;
+        public const int MaximumMessageSize = 256 * 1024 - MessageAttributesReservedSize;
         public const int MaximumItemsInBatch = 10;
 
         ReadOnlySettings settings;

--- a/src/Tests/BatcherTests.cs
+++ b/src/Tests/BatcherTests.cs
@@ -111,14 +111,14 @@ namespace Tests
         {
             var preparedMessages = new[]
             {
-                new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(256)},
+                new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(255)},
 
-                new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(256)},
+                new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(255)},
 
                 new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(64)},
                 new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(64)},
                 new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(64)},
-                new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(64)},
+                new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(63)},
 
                 new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(200)},
                 new PreparedMessage{ MessageId = Guid.NewGuid().ToString(), Destination = "destination1", QueueUrl = "https://destination1", Body = GenerateBody(10)},


### PR DESCRIPTION
Simple solution to #318. reserving small part of message limit for used attributes 