### PR TITLE
Put as many messages in batch as possible

### DIFF
--- a/src/NServiceBus.AmazonSQS/Batcher.cs
+++ b/src/NServiceBus.AmazonSQS/Batcher.cs
@@ -40,7 +40,7 @@ namespace NServiceBus.Transports.SQS
                     {
                         allBatches.Add(message.ToBatchRequest(currentDestinationBatches));
                         currentDestinationBatches.Clear();
-                        payloadSize = bodyLength;
+                        payloadSize = 0;
                     }
                 }
 


### PR DESCRIPTION
From https://github.com/Particular/NServiceBus.AmazonSQS/pull/320

payloadSize was not tracking size of currentDestinationBatches correctly. 

When sending messages with size around _TransportConfiguration.MaximumMessageSize / TransportConfiguration.MaximumItemsInBatch_, all batches besides the first one were having _TransportConfiguration.MaximumItemsInBatch - 1_ items instead of _TransportConfiguration.MaximumItemsInBatch_

