### PR TITLE
Resolve failing test

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -23,4 +23,8 @@
       <Link>Cleanup.cs</Link>
     </Compile>
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="\**\NSB.AcceptanceTests\Routing\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
+  </ItemGroup>
 </Project>

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -1,0 +1,125 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    // NOTE: This test was copied from core to allow it to run with AutoSubscribe
+    public class When_publishing_an_event_implementing_two_unrelated_interfaces : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Event_should_be_published_using_instance_type()
+        {
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.EventASubscribed && c.EventBSubscribed, (session, ctx) =>
+                    {
+                        var message = new CompositeEvent
+                        {
+                            ContextId = ctx.Id
+                        };
+                        return session.Publish(message);
+                    }))
+                .WithEndpoint<Subscriber>(b => b.When((session, ctx) =>
+                {
+                    ctx.EventASubscribed = true;
+                    ctx.EventBSubscribed = true;
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.GotEventA && c.GotEventB)
+                .Run(TimeSpan.FromSeconds(20));
+
+            Assert.True(context.GotEventA);
+            Assert.True(context.GotEventB);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool EventASubscribed { get; set; }
+            public bool EventBSubscribed { get; set; }
+            public bool GotEventA { get; set; }
+            public bool GotEventB { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>();
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class EventAHandler : IHandleMessages<IEventA>
+            {
+                public EventAHandler(Context context)
+                {
+                    testContext = context;
+                }
+
+                public Task Handle(IEventA @event, IMessageHandlerContext context)
+                {
+                    if (@event.ContextId != testContext.Id)
+                    {
+                        return Task.FromResult(0);
+                    }
+                    testContext.GotEventA = true;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+
+            public class EventBHandler : IHandleMessages<IEventB>
+            {
+                public EventBHandler(Context context)
+                {
+                    testContext = context;
+                }
+
+                public Task Handle(IEventB @event, IMessageHandlerContext context)
+                {
+                    if (@event.ContextId != testContext.Id)
+                    {
+                        return Task.FromResult(0);
+                    }
+
+                    testContext.GotEventB = true;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class CompositeEvent : IEventA, IEventB
+        {
+            public Guid ContextId { get; set; }
+            public string StringProperty { get; set; }
+            public int IntProperty { get; set; }
+        }
+
+        public interface IEventA : IEvent
+        {
+            Guid ContextId { get; set; }
+            string StringProperty { get; set; }
+        }
+
+        public interface IEventB : IEvent
+        {
+            Guid ContextId { get; set; }
+            int IntProperty { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
This test attempts to subscribe to two different events and the transport under the covers can take quite a long time to do that because of https://github.com/aws/aws-sdk-net/issues/1569

Unfortunately this results in the test failing because it exceeds the timeout given to test setup outlined here https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs#L144-L146

The test doesn't need to subscribe after startup on this transport. It only needs that if the transport relies on message-driven pub-sub (to ensure that we record when the subscribers are all wired up). For the current version of SQS, the autosubscribe feature is able to set things up for us at endpoint startup, and we take advantage of the fact that we know we're single threaded when we do that.