### PR TITLE
Avoid casting down the transport infrastructure and use reflection to access the factory field instead

### DIFF
--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
@@ -126,12 +126,6 @@
 
         public override TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure()
         {
-            //NServiceBus core only calls this method if endpoint is not send-only. The null path is only used by SettlePolicy class
-            //that retrieves the subscription manager in order to call Settle on it
-            if (settings.GetOrDefault<bool>("Endpoint.SendOnly"))
-            {
-                return new TransportSubscriptionInfrastructure(() => null);
-            }
             if (SubscriptionManager == null)
             {
                 SubscriptionManager = new SubscriptionManager(sqsClient,

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
@@ -126,6 +126,12 @@
 
         public override TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure()
         {
+            //NServiceBus core only calls this method if endpoint is not send-only. The null path is only used by SettlePolicy class
+            //that retrieves the subscription manager in order to call Settle on it
+            if (settings.GetOrDefault<bool>("Endpoint.SendOnly"))
+            {
+                return new TransportSubscriptionInfrastructure(() => null);
+            }
             if (SubscriptionManager == null)
             {
                 SubscriptionManager = new SubscriptionManager(sqsClient,

--- a/src/NServiceBus.Transport.SQS/SettlePolicy.cs
+++ b/src/NServiceBus.Transport.SQS/SettlePolicy.cs
@@ -10,6 +10,7 @@ namespace NServiceBus.Transport.SQS
         public SettlePolicy()
         {
             DependsOnOptionally<AutoSubscribe>(); // will enforce this feature to run after AutoSubscribe if present
+            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Subscribing to events is only allowed in non-send-only endpoints.");
         }
 
         protected override void Setup(FeatureConfigurationContext context)

--- a/src/NServiceBus.Transport.SQS/SettlePolicy.cs
+++ b/src/NServiceBus.Transport.SQS/SettlePolicy.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Transport.SQS
     using System;
     using System.Reflection;
     using System.Threading.Tasks;
-    using Configure;
     using Features;
 
     class SettlePolicy : Feature


### PR DESCRIPTION
Version 5 of the transport introduced a new class `SettlePolicy` for the purpose of executing all the autosubscribe requests in a single go. This has been added because executing them concurrently without batching caused resulted in overwriting the policy.

The `SettlePolicy` obtained reference to the transport infrastructure object and attempted to downcast it to the specific SQS transport infrastructure type. This broke the serverless packages which rely on the ability to wrap the transport infrastructure in order to substitute the message pump with a no-op implementation. 

This change replaces the downcast with usage of public API `ConfigureSubscriptionInfrastructure()`, taking advantage of the fact that the implementation of the subscription manager factory method always returns the same instance. Unfortunately the `SubscriptionManagerFactory` property is internal so it needs to be invoked via reflection. BTW, the same hack is used by NServiceBus.Raw.