### PR TITLE
Avoid casting down the transport infrastructure

### DIFF
--- a/src/NServiceBus.Transport.SQS/SettlePolicy.cs
+++ b/src/NServiceBus.Transport.SQS/SettlePolicy.cs
@@ -1,7 +1,8 @@
 namespace NServiceBus.Transport.SQS
 {
+    using System;
+    using System.Reflection;
     using System.Threading.Tasks;
-    using Configure;
     using Features;
 
     class SettlePolicy : Feature
@@ -9,14 +10,23 @@ namespace NServiceBus.Transport.SQS
         public SettlePolicy()
         {
             DependsOnOptionally<AutoSubscribe>(); // will enforce this feature to run after AutoSubscribe if present
+            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Subscribing to events is only allowed in non-send-only endpoints.");
         }
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var transportInfrastructure = (SqsTransportInfrastructure)context.Settings.Get<TransportInfrastructure>();
+            var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
 
             // with Core 7.2.4 the startup task will run after the auto subscribe startup task
-            context.RegisterStartupTask(b => new SettlePolicyTask(transportInfrastructure.SubscriptionManager));
+            context.RegisterStartupTask(b => new SettlePolicyTask(CreateSubscriptionManager(transportInfrastructure)));
+        }
+
+        static IManageSubscriptions CreateSubscriptionManager(TransportInfrastructure transportInfra)
+        {
+            var subscriptionInfra = transportInfra.ConfigureSubscriptionInfrastructure();
+            var factoryProperty = typeof(TransportSubscriptionInfrastructure).GetProperty("SubscriptionManagerFactory", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var factoryInstance = (Func<IManageSubscriptions>)factoryProperty.GetValue(subscriptionInfra, new object[0]);
+            return factoryInstance();
         }
 
         class SettlePolicyTask : FeatureStartupTask


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.AmazonSQS/pull/552. See original PR for rationale.