### PR TITLE
Update SDK to 3.5 and suppress policy usage

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -7,9 +7,9 @@
     <RootNamespace>NServiceBus.AcceptanceTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.111.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.103.15" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.102.5" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.3.4" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.28" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.0.29" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.630" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
@@ -320,6 +320,17 @@
             throw new NotImplementedException();
         }
 
+        public DeleteBucketOwnershipControlsResponse DeleteBucketOwnershipControls(DeleteBucketOwnershipControlsRequest request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DeleteBucketOwnershipControlsResponse> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            throw new NotImplementedException();
+        }
+
         public DeleteBucketPolicyResponse DeleteBucketPolicy(string bucketName)
         {
             throw new NotImplementedException();
@@ -626,6 +637,17 @@
         }
 
         public Task<GetBucketNotificationResponse> GetBucketNotificationAsync(GetBucketNotificationRequest request, CancellationToken cancellationToken = new CancellationToken())
+        {
+            throw new NotImplementedException();
+        }
+
+        public GetBucketOwnershipControlsResponse GetBucketOwnershipControls(GetBucketOwnershipControlsRequest request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<GetBucketOwnershipControlsResponse> GetBucketOwnershipControlsAsync(GetBucketOwnershipControlsRequest request,
+            CancellationToken cancellationToken = new CancellationToken())
         {
             throw new NotImplementedException();
         }
@@ -1200,6 +1222,17 @@
             throw new NotImplementedException();
         }
 
+        public PutBucketOwnershipControlsResponse PutBucketOwnershipControls(PutBucketOwnershipControlsRequest request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PutBucketOwnershipControlsResponse> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            throw new NotImplementedException();
+        }
+
         public PutBucketPolicyResponse PutBucketPolicy(string bucketName, string policy)
         {
             throw new NotImplementedException();
@@ -1444,6 +1477,8 @@
         {
             throw new NotImplementedException();
         }
+
+        public IS3PaginatorFactory Paginators { get; }
 
         #endregion
     }

--- a/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
@@ -10,9 +10,11 @@
 
     class MockSqsClient : IAmazonSQS
     {
-        public IClientConfig Config { get; } = new AmazonSQSConfig();
+        public IClientConfig Config { get; } = new AmazonSQSConfig
+        {
+            ServiceURL = "http://fakeServiceUrl"
+        };
         public List<string> QueueUrlRequestsSent { get; } = new List<string>();
-
 
         public Task<GetQueueUrlResponse> GetQueueUrlAsync(string queueName, CancellationToken cancellationToken = new CancellationToken())
         {
@@ -511,6 +513,8 @@
         {
             throw new NotImplementedException();
         }
+
+        public ISQSPaginatorFactory Paginators { get; }
 
         #endregion
     }

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -9,8 +9,8 @@
     <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.111.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.103.15" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.3.4" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.28" />
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.630" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
@@ -231,7 +231,9 @@ namespace NServiceBus.Transport.SQS.Tests
 
             await manager.Settle();
 
+#pragma warning disable 618
             var policy = Policy.FromJson(sqsClient.SetAttributesRequestsSent[0].attributes["Policy"]);
+#pragma warning restore 618
 
             Assert.IsEmpty(setAttributeRequestsSentBeforeSettle);
             Assert.AreEqual(2, policy.Statements.Count);

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -7,8 +7,8 @@
     <RootNamespace>TransportTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.111.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.103.15" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.3.4" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.5.0.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.630" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/src/NServiceBus.Transport.SQS/Extensions/PolicyExtensions.cs
+++ b/src/NServiceBus.Transport.SQS/Extensions/PolicyExtensions.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Transport.SQS.Extensions
     using Amazon.Auth.AccessControlPolicy;
     using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
+#pragma warning disable 618
     static class PolicyExtensions
     {
         internal static bool HasSQSPermission(this Policy policy, Statement addStatement)
@@ -60,4 +61,5 @@ namespace NServiceBus.Transport.SQS.Extensions
             return statement;
         }
     }
+#pragma warning restore 618
 }

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.3.110.11, 3.4)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.3.102.60, 3.4)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.3.101.1, 3.4)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.5, 3.6)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.5, 3.6)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.5, 3.6)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.630, 9.0.0)" />
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.SQS/SubscriptionManager.cs
+++ b/src/NServiceBus.Transport.SQS/SubscriptionManager.cs
@@ -296,6 +296,7 @@ namespace NServiceBus.Transport.SQS
             return Task.Delay(millisecondsDelay, token);
         }
 
+#pragma warning disable 618
         static Policy ExtractPolicy(Dictionary<string, string> queueAttributes)
         {
             Policy policy;
@@ -316,6 +317,7 @@ namespace NServiceBus.Transport.SQS
 
             return policy;
         }
+#pragma warning restore 618
 
         void MarkTypeConfigured(Type eventType)
         {
@@ -342,6 +344,7 @@ namespace NServiceBus.Transport.SQS
 
         static ILog Logger = LogManager.GetLogger(typeof(SubscriptionManager));
 
+#pragma warning disable 618
         class PolicyStatement
         {
             public PolicyStatement(string topicName, string topicArn, Statement statement, string queueArn)
@@ -359,4 +362,5 @@ namespace NServiceBus.Transport.SQS
             public Statement Statement { get; }
         }
     }
+#pragma warning restore 618
 }


### PR DESCRIPTION
Alternative to https://github.com/Particular/NServiceBus.AmazonSQS/pull/576 which unblocks 3.5 SDK

The policy objects are still there and still fully functional (they are still in use in SQS as well). So until they are really removed I guess the best way is to pragma disable the warning. Once the SDK itself has been adjusted we hopefully have a good way we can borrow from the SDK to settle the policy again or maybe https://github.com/aws/aws-sdk-net/issues/1569 has been resolved