### PR TITLE
Merge pull request #552 from Particular/avoid-casting-transport-infra

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/APIApprovals.cs
@@ -11,7 +11,7 @@
         [Test]
         public void ApproveSqsTransport()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(SqsTransport).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(SqsTransport).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" });
             Approver.Verify(publicApi);
         }
     }

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />
-    <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
+    <!-- PublicApiGenerator should be locked to the version 9.x as verions 10.x and later does not support .NET Framework 4.5.2 -->
+    <PackageReference Include="PublicApiGenerator" Version="[9.3.0, 10.0.0)" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Avoid casting down the transport infrastructure and use reflection to access the factory field instead