### PR TITLE
CLI Tool: Allow setting explicit event or wildcard based policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ installer/ServiceControl-cache
 *.sln.docstates
 .vs/
 local.settings.json
+.vscode/
 
 # mac temp file ignore
 .DS_Store

--- a/src/CommandLine/Endpoint.cs
+++ b/src/CommandLine/Endpoint.cs
@@ -94,9 +94,9 @@
             }
         }
 
-        public static async Task SetEventsBasedPolicy(IAmazonSQS sqs, IAmazonSimpleNotificationService sns, string prefix, string endpointName, IEnumerable<string> eventTypes)
+        public static async Task SetPolicy(IAmazonSQS sqs, IAmazonSimpleNotificationService sns, string prefix, string endpointName, IEnumerable<string> eventTypes, bool addAccountCondition, bool addPrefixcondition, IReadOnlyList<string> namespaceConditions)
         {
-            await Console.Out.WriteLineAsync($"Setting event based delivery policies on endpoint '{endpointName}'.");
+            await Console.Out.WriteLineAsync($"Setting policy on endpoint '{endpointName}'.");
 
             var policyStatements = new List<PolicyStatement>();
             var queueUrl = await Queue.GetUrl(sqs, prefix, endpointName);
@@ -111,10 +111,10 @@
             var policy = queueAttributes.ExtractPolicy();
 
             if (!policy.Update(policyStatements,
-                false, // configuration.AddAccountConditionForPolicies,
-                false, // configuration.AddTopicNamePrefixConditionForPolicies,
-                new List<string>(), // configuration.NamespaceConditionsForPolicies,
-                prefix, // configuration.TopicNamePrefix,
+                addAccountCondition, 
+                addPrefixcondition,
+                namespaceConditions,
+                prefix,
                 queueArn))
             {
                 await Console.Out.WriteLineAsync($"Policy on endpoint '{endpointName}' not set.");

--- a/src/CommandLine/Endpoint.cs
+++ b/src/CommandLine/Endpoint.cs
@@ -84,6 +84,12 @@
 
             var queueArn = await Queue.GetArn(sqs, prefix, endpointName);
             var topicArn = await Topic.Get(sns, prefix, eventType);
+            if (topicArn == null)
+            {
+                await Console.Out.WriteLineAsync($"No topic detected for event type '{eventType}', please subscribe to the event type first..");
+                return;
+            }
+            
             await Topic.Unsubscribe(sns, topicArn, queueArn);
 
             await Console.Out.WriteLineAsync($"Endpoint '{endpointName}' unsubscribed from '{eventType}'.");
@@ -106,6 +112,12 @@
             foreach (var eventType in eventTypes)
             {
                 var topicArn = await Topic.Get(sns, prefix, eventType);
+                if (topicArn == null)
+                {
+                    await Console.Out.WriteLineAsync($"No topic detected for event type '{eventType}', please subscribe to the event type first..");
+                    await Console.Out.WriteLineAsync($"Policy on endpoint '{endpointName}' not set.");
+                    return;
+                }
                 policyStatements.Add(new PolicyStatement($"{prefix}{eventType}", topicArn, queueArn));
             }
 

--- a/src/CommandLine/Endpoint.cs
+++ b/src/CommandLine/Endpoint.cs
@@ -71,8 +71,10 @@
             await Console.Out.WriteLineAsync($"Subscribing endpoint '{endpointName}' to '{eventType}'.");
 
             var queueUrl = await Queue.GetUrl(sqs, prefix, endpointName);
+            var queueAttributes = await sqs.GetAttributesAsync(queueUrl).ConfigureAwait(false);
+            var queueArn = queueAttributes["QueueArn"];
             var topicArn = await Topic.Create(sns, prefix, eventType);
-            await Topic.Subscribe(sqs, sns, topicArn, queueUrl);
+            await Topic.Subscribe(sqs, sns, topicArn, queueArn);
 
             await Console.Out.WriteLineAsync($"Endpoint '{endpointName}' subscribed to '{eventType}'.");
         }

--- a/src/CommandLine/Endpoint.cs
+++ b/src/CommandLine/Endpoint.cs
@@ -103,7 +103,8 @@
             var queueAttributes = await sqs.GetAttributesAsync(queueUrl).ConfigureAwait(false);
             var queueArn = queueAttributes["QueueArn"];
 
-            foreach(var eventType in eventTypes){
+            foreach (var eventType in eventTypes)
+            {
                 var topicArn = await Topic.Get(sns, prefix, eventType);
                 policyStatements.Add(new PolicyStatement($"{prefix}{eventType}", topicArn, queueArn));
             }
@@ -124,7 +125,25 @@
             var setAttributes = new Dictionary<string, string> {{"Policy", policy.ToJson()}};
             await sqs.SetAttributesAsync(queueUrl, setAttributes).ConfigureAwait(false);
 
-            await Console.Out.WriteLineAsync($"Policy on endpoint '{endpointName}' not set.");
+            await Console.Out.WriteLineAsync($"Policy on endpoint '{endpointName}' set.");
+        }
+
+        public static async Task ListPolicy(IAmazonSQS sqs, IAmazonSimpleNotificationService sns, string prefix, string endpointName)
+        {
+            try
+            {
+                await Console.Out.WriteLineAsync($"Listing policy on endpoint '{endpointName}':");
+
+                var queueUrl = await Queue.GetUrl(sqs, prefix, endpointName);
+                var queueAttributes = await sqs.GetAttributesAsync(queueUrl).ConfigureAwait(false);
+                var policy = queueAttributes.ExtractPolicy();
+
+                await Console.Out.WriteLineAsync(policy.ToJson());
+            }
+            catch (Exception ex)
+            {
+                await Console.Out.WriteLineAsync($"Failed to list policy: {ex.Message}");
+            }
         }
     }
 }

--- a/src/CommandLine/Endpoint.cs
+++ b/src/CommandLine/Endpoint.cs
@@ -130,7 +130,7 @@
                 prefix,
                 queueArn))
             {
-                await Console.Out.WriteLineAsync($"Policy on endpoint '{endpointName}' not set.");
+                await Console.Out.WriteLineAsync($"No updates needed for policy on endpoint '{endpointName}'.");
                 return;
             }
 

--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.111.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.103.15" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.102.5" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.7.6" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.8" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.30" />
     <PackageReference Include="Particular.CodeRules" Version="0.8.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/CommandLine/PolicyExtensions.cs
+++ b/src/CommandLine/PolicyExtensions.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.Transport.SQS.CommandLine
     using Amazon.Auth.AccessControlPolicy;
     using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
-#pragma warning disable 618
     static class PolicyExtensions
     {
         internal static bool Update(this Policy policy,
@@ -146,10 +145,12 @@ namespace NServiceBus.Transport.SQS.CommandLine
         private static bool StatementContainsResources(this Statement statement, IEnumerable<Resource> resources) =>
             resources.All(resource => statement.Resources.FirstOrDefault(x => string.Equals(x.Id, resource.Id)) != null);
 
+#pragma warning disable 618
         private static bool StatementContainsActions(
             this Statement statement,
             IEnumerable<ActionIdentifier> actions) =>
             actions.All(action => statement.Actions.FirstOrDefault(x => string.Equals(x.ActionName, action.ActionName)) != null);
+#pragma warning restore 618
 
         private static bool StatementContainsPrincipals(
             this Statement statement,
@@ -172,6 +173,7 @@ namespace NServiceBus.Transport.SQS.CommandLine
             this Statement statement) =>
             statement.Conditions.Any(condition => condition.Values.All(v => v.Contains("*")));
 
+#pragma warning disable 618
         private static Statement CreatePermissionStatementForQueueMatching(string queueArn, IEnumerable<string> topicArnMatchPatterns)
         {
             var statement = new Statement(Statement.StatementEffect.Allow);
@@ -182,10 +184,9 @@ namespace NServiceBus.Transport.SQS.CommandLine
             statement.Conditions.Add(queuePermissionCondition);
             return statement;
         }
-
+#pragma warning restore 618
         // conditions are case sensitive
         // https://stackoverflow.com/a/47769284/290290
         private static readonly StringComparer OrdinalComparer = StringComparer.Ordinal;
     }
-#pragma warning restore 618
 }

--- a/src/CommandLine/PolicyExtensions.cs
+++ b/src/CommandLine/PolicyExtensions.cs
@@ -1,0 +1,198 @@
+namespace NServiceBus.Transport.SQS.CommandLine
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using Amazon.Auth.AccessControlPolicy;
+    using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
+
+#pragma warning disable 618
+    static class PolicyExtensions
+    {
+        internal static bool Update(this Policy policy, 
+            IReadOnlyCollection<PolicyStatement> addPolicyStatements,
+            bool addAccountConditionForPolicies, 
+            bool addTopicNamePrefixConditionForPolicies,
+            IReadOnlyList<string> namespaceConditionsForPolicies, 
+            string topicNamePrefix, 
+            string sqsQueueArn)
+        {
+            if (addPolicyStatements.Count == 0)
+            {
+                return false;
+            }
+
+            var policyModified = false;
+            var wildcardConditions = new List<string>();
+            if (addAccountConditionForPolicies)
+            {
+                wildcardConditions.AddRange(addPolicyStatements.Select(s => $"{s.AccountArn}:*").Distinct());
+            }
+
+            if (addTopicNamePrefixConditionForPolicies)
+            {
+                wildcardConditions.AddRange(addPolicyStatements
+                    .Select(s => $"{s.AccountArn}:{topicNamePrefix}*").Distinct());
+            }
+
+            if (namespaceConditionsForPolicies.Count > 0)
+            {
+                wildcardConditions.AddRange(namespaceConditionsForPolicies
+                    .SelectMany(ns => addPolicyStatements
+                        .Select(s => $"{s.AccountArn}")
+                        .Distinct()
+                        .Select(arn => $"{arn}:{GetNamespaceName(topicNamePrefix, ns)}*")));
+            }
+
+            var wildCardQueuePermissionStatements = CreatePermissionStatementForQueueMatching(sqsQueueArn, wildcardConditions);
+            var explicitQueuePermissionStatements =
+                CreatePermissionStatementForQueueMatching(sqsQueueArn, addPolicyStatements.Select(s => s.TopicArn));
+
+            if (wildcardConditions.Count > 0 || !policy.ContainsPermission(explicitQueuePermissionStatements))
+            {
+                var statementToRemoves = policy.Statements
+                    .Where(statement => statement.CoveredByPermission(explicitQueuePermissionStatements)).ToList();
+                foreach (var statementToRemove in statementToRemoves)
+                {
+                    policy.Statements.Remove(statementToRemove);
+                    policyModified = true;
+                }
+
+                if (wildcardConditions.Count == 0)
+                {
+                    policy.Statements.Add(explicitQueuePermissionStatements);
+
+                    var wildCardStatementsToRemove = policy.Statements
+                        .Where(statement => statement.CoveredByWildcard(explicitQueuePermissionStatements)).ToList();
+                    foreach (var statementToRemove in wildCardStatementsToRemove)
+                    {
+                        policy.Statements.Remove(statementToRemove);
+                    }
+
+                    policyModified = true;
+                }
+            }
+
+            if (wildcardConditions.Count > 0 && !policy.ContainsPermission(wildCardQueuePermissionStatements))
+            {
+                var statementToRemoves = policy.Statements
+                    .Where(statement => statement.CoveredByWildcard(wildCardQueuePermissionStatements)).ToList();
+                foreach (var statementToRemove in statementToRemoves)
+                {
+                    policy.Statements.Remove(statementToRemove);
+                }
+
+                policy.Statements.Add(wildCardQueuePermissionStatements);
+
+                policyModified = true;
+            }
+
+            return policyModified;
+        }
+
+        internal static Policy ExtractPolicy(this Dictionary<string, string> queueAttributes)
+        {
+            string policyStr = null;
+            if (queueAttributes.ContainsKey("Policy"))
+            {
+                policyStr = queueAttributes["Policy"];
+            }
+
+            return string.IsNullOrEmpty(policyStr) ? new Policy() : Policy.FromJson(policyStr);
+        }
+
+        private static string GetNamespaceName(string topicNamePrefix, string namespaceName)
+        {
+            // SNS topic names can only have alphanumeric characters, hyphens and underscores.
+            // Any other characters will be replaced with a hyphen.
+            var namespaceNameBuilder = new StringBuilder(namespaceName);
+            for (var i = 0; i < namespaceNameBuilder.Length; ++i)
+            {
+                var c = namespaceNameBuilder[i];
+                if (!char.IsLetterOrDigit(c)
+                    && c != '-'
+                    && c != '_')
+                {
+                    namespaceNameBuilder[i] = '-';
+                }
+            }
+
+            // topicNamePrefix should not be sanitized
+            return topicNamePrefix + namespaceNameBuilder;
+        }
+
+        private static bool ContainsPermission(this Policy policy, Statement statement)
+        {
+            if (policy.Statements == null)
+            {
+                return false;
+            }
+
+            return policy.Statements.Any(stmt => stmt.Effect == statement.Effect &&
+                                                       stmt.StatementContainsResources(statement.Resources) &&
+                                                       stmt.StatementContainsActions(statement.Actions) &&
+                                                       stmt.StatementContainsConditions(statement.Conditions) &&
+                                                       stmt.StatementContainsPrincipals(statement.Principals));
+        }
+
+        private static bool CoveredByPermission(this Statement statement, Statement permission) =>
+            statement.Effect == permission.Effect &&
+            statement.StatementContainsResources(permission.Resources) &&
+            statement.StatementContainsActions(permission.Actions) &&
+            statement.StatementCoveredByConditions(permission.Conditions) &&
+            statement.StatementContainsPrincipals(permission.Principals);
+
+        private static bool CoveredByWildcard(this Statement statement, Statement permission) =>
+            statement.Effect == permission.Effect &&
+            statement.StatementContainsResources(permission.Resources) &&
+            statement.StatementContainsActions(permission.Actions) &&
+            statement.StatementCoveredByWildcardConditions() &&
+            statement.StatementContainsPrincipals(permission.Principals);
+
+        private static bool StatementContainsResources(this Statement statement, IEnumerable<Resource> resources) =>
+            resources.All(resource => statement.Resources.FirstOrDefault(x => string.Equals(x.Id, resource.Id)) != null);
+
+        private static bool StatementContainsActions(
+            this Statement statement,
+            IEnumerable<ActionIdentifier> actions) =>
+            actions.All(action => statement.Actions.FirstOrDefault(x => string.Equals(x.ActionName, action.ActionName)) != null);
+
+        private static bool StatementContainsPrincipals(
+            this Statement statement,
+            IEnumerable<Principal> principals) =>
+            principals.All(principal => statement.Principals.FirstOrDefault(x => string.Equals(x.Id, principal.Id) && string.Equals(x.Provider, principal.Provider)) != null);
+
+        private static bool StatementContainsConditions(
+            this Statement statement,
+            IEnumerable<Condition> conditions) =>
+            conditions.All(condition => statement.Conditions.FirstOrDefault(x => string.Equals(x.Type, condition.Type) &&
+                string.Equals(x.ConditionKey, condition.ConditionKey) &&
+                x.Values.OrderBy(v => v, OrdinalComparer).SequenceEqual(condition.Values.OrderBy(v => v, OrdinalComparer), OrdinalComparer)) != null);
+
+        private static bool StatementCoveredByConditions(
+            this Statement statement,
+            IList<Condition> conditions) =>
+            statement.Conditions.Any(condition => conditions.Any(x => string.Equals(x.Type, condition.Type) && string.Equals(x.ConditionKey, condition.ConditionKey) && condition.Values.All(v => x.Values.Contains(v, OrdinalComparer))));
+
+        private static bool StatementCoveredByWildcardConditions(
+            this Statement statement) =>
+            statement.Conditions.Any(condition => condition.Values.All(v => v.Contains("*")));
+
+        internal static Statement CreatePermissionStatementForQueueMatching(string queueArn, IEnumerable<string> topicArnMatchPatterns)
+        {
+            var statement = new Statement(Statement.StatementEffect.Allow);
+            statement.Actions.Add(SQSActionIdentifiers.SendMessage);
+            statement.Resources.Add(new Resource(queueArn));
+            statement.Principals.Add(new Principal("*"));
+            var queuePermissionCondition = new Condition(ConditionFactory.ArnComparisonType.ArnLike.ToString(), "aws:SourceArn", topicArnMatchPatterns.OrderBy(t => t, OrdinalComparer).ToArray());
+            statement.Conditions.Add(queuePermissionCondition);
+            return statement;
+        }
+
+        // conditions are case sensitive
+        // https://stackoverflow.com/a/47769284/290290
+        private static readonly StringComparer OrdinalComparer = StringComparer.Ordinal;
+    }
+#pragma warning restore 618
+}

--- a/src/CommandLine/PolicyExtensions.cs
+++ b/src/CommandLine/PolicyExtensions.cs
@@ -10,12 +10,12 @@ namespace NServiceBus.Transport.SQS.CommandLine
 #pragma warning disable 618
     static class PolicyExtensions
     {
-        internal static bool Update(this Policy policy, 
+        internal static bool Update(this Policy policy,
             IReadOnlyCollection<PolicyStatement> addPolicyStatements,
-            bool addAccountConditionForPolicies, 
+            bool addAccountConditionForPolicies,
             bool addTopicNamePrefixConditionForPolicies,
-            IReadOnlyList<string> namespaceConditionsForPolicies, 
-            string topicNamePrefix, 
+            IReadOnlyList<string> namespaceConditionsForPolicies,
+            string topicNamePrefix,
             string sqsQueueArn)
         {
             var parts = sqsQueueArn.Split(":", StringSplitOptions.RemoveEmptyEntries);
@@ -172,7 +172,7 @@ namespace NServiceBus.Transport.SQS.CommandLine
             this Statement statement) =>
             statement.Conditions.Any(condition => condition.Values.All(v => v.Contains("*")));
 
-        internal static Statement CreatePermissionStatementForQueueMatching(string queueArn, IEnumerable<string> topicArnMatchPatterns)
+        private static Statement CreatePermissionStatementForQueueMatching(string queueArn, IEnumerable<string> topicArnMatchPatterns)
         {
             var statement = new Statement(Statement.StatementEffect.Allow);
             statement.Actions.Add(SQSActionIdentifiers.SendMessage);

--- a/src/CommandLine/PolicyStatement.cs
+++ b/src/CommandLine/PolicyStatement.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.Transport.SQS.CommandLine
 {
-    using System;
-    using System.Linq;
     using Amazon.Auth.AccessControlPolicy;
     using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
@@ -21,7 +19,7 @@ namespace NServiceBus.Transport.SQS.CommandLine
         public string TopicArn { get; }
         public Statement Statement { get; }
 
-        internal static Statement CreatePermissionStatement(string queueArn, string topicArn)
+        private static Statement CreatePermissionStatement(string queueArn, string topicArn)
         {
             var statement = new Statement(Statement.StatementEffect.Allow);
             statement.Actions.Add(SQSActionIdentifiers.SendMessage);
@@ -30,8 +28,6 @@ namespace NServiceBus.Transport.SQS.CommandLine
             statement.Principals.Add(new Principal("*"));
             return statement;
         }
-
-        private static readonly string[] ArnSeperator = { ":" };
     }
 #pragma warning restore 618
 }

--- a/src/CommandLine/PolicyStatement.cs
+++ b/src/CommandLine/PolicyStatement.cs
@@ -1,0 +1,41 @@
+namespace NServiceBus.Transport.SQS.CommandLine
+{
+    using System;
+    using System.Linq;
+    using Amazon.Auth.AccessControlPolicy;
+    using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
+
+#pragma warning disable 618
+    class PolicyStatement
+    {
+        public PolicyStatement(string topicName, string topicArn, string queueArn)
+        {
+            TopicName = topicName;
+            TopicArn = topicArn;
+            Statement = CreatePermissionStatement(queueArn, topicArn);
+            QueueArn = queueArn;
+
+            var splittedTopicArn = TopicArn.Split(ArnSeperator, StringSplitOptions.RemoveEmptyEntries);
+            AccountArn = string.Join(":", splittedTopicArn.Take(5));
+        }
+
+        public string QueueArn { get; }
+        public string TopicName { get; }
+        public string TopicArn { get; }
+        public string AccountArn { get; }
+        public Statement Statement { get; }
+
+        internal static Statement CreatePermissionStatement(string queueArn, string topicArn)
+        {
+            var statement = new Statement(Statement.StatementEffect.Allow);
+            statement.Actions.Add(SQSActionIdentifiers.SendMessage);
+            statement.Resources.Add(new Resource(queueArn));
+            statement.Conditions.Add(ConditionFactory.NewSourceArnCondition(topicArn));
+            statement.Principals.Add(new Principal("*"));
+            return statement;
+        }
+
+        private static readonly string[] ArnSeperator = { ":" };
+    }
+#pragma warning restore 618
+}

--- a/src/CommandLine/PolicyStatement.cs
+++ b/src/CommandLine/PolicyStatement.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Transport.SQS.CommandLine
     using Amazon.Auth.AccessControlPolicy;
     using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
-#pragma warning disable 618
     class PolicyStatement
     {
         public PolicyStatement(string topicName, string topicArn, string queueArn)
@@ -19,6 +18,7 @@ namespace NServiceBus.Transport.SQS.CommandLine
         public string TopicArn { get; }
         public Statement Statement { get; }
 
+#pragma warning disable 618
         private static Statement CreatePermissionStatement(string queueArn, string topicArn)
         {
             var statement = new Statement(Statement.StatementEffect.Allow);
@@ -28,6 +28,6 @@ namespace NServiceBus.Transport.SQS.CommandLine
             statement.Principals.Add(new Principal("*"));
             return statement;
         }
-    }
 #pragma warning restore 618
+    }
 }

--- a/src/CommandLine/PolicyStatement.cs
+++ b/src/CommandLine/PolicyStatement.cs
@@ -14,15 +14,11 @@ namespace NServiceBus.Transport.SQS.CommandLine
             TopicArn = topicArn;
             Statement = CreatePermissionStatement(queueArn, topicArn);
             QueueArn = queueArn;
-
-            var splittedTopicArn = TopicArn.Split(ArnSeperator, StringSplitOptions.RemoveEmptyEntries);
-            AccountArn = string.Join(":", splittedTopicArn.Take(5));
         }
 
         public string QueueArn { get; }
         public string TopicName { get; }
         public string TopicArn { get; }
-        public string AccountArn { get; }
         public Statement Statement { get; }
 
         internal static Statement CreatePermissionStatement(string queueArn, string topicArn)

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -13,8 +13,9 @@
     // sqs-transport endpoint remove large-message-support bucket-name [--other-options]
     // sqs-transport endpoint remove remove delay-delivery-support [--other-options]
     // sqs-transport endpoint delete name [--other-options]
-    // sqs-transport endpoint policy name wildcard --account --namespace "namespacename" --prefix "prefix" [--other-options] 
-    // sqs-transport endpoint policy name events --event-type "event-type1" --event-type "event-type2" [--other-options] 
+    // sqs-transport endpoint set-policy name wildcard --account --namespace "namespacename" --prefix "prefix" [--other-options] 
+    // sqs-transport endpoint set-policy name events --event-type "event-type1" --event-type "event-type2" [--other-options] 
+    // sqs-transport endpoint list-policy name [--other-options]
     class Program
     {
         static int Main(string[] args)
@@ -238,7 +239,7 @@
                     });
                 });
             
-                endpointCommand.Command("policy", policyCommand => 
+                endpointCommand.Command("set-policy", policyCommand => 
                 {
                     policyCommand.Description = "Sets the IAM policy for an endpoint.";
                     var nameArgument = policyCommand.Argument("name", "Name of the endpoint (required)").IsRequired();
@@ -252,7 +253,6 @@
 
                     policyCommand.Command("events", policyBasedOneventsCommand =>
                     {
-                         
                         policyBasedOneventsCommand.Options.Add(accessKeyOption);
                         policyBasedOneventsCommand.Options.Add(regionOption);
                         policyBasedOneventsCommand.Options.Add(secretOption);
@@ -264,7 +264,7 @@
                         };
                         policyBasedOneventsCommand.Options.Add(eventTypeOption);
 
-                        policyBasedOneventsCommand.OnExecute(async () =>
+                        policyBasedOneventsCommand.OnExecuteAsync(async ct =>
                         {
                             var endpointName = nameArgument.Value;
                             var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;
@@ -272,7 +272,6 @@
 
                             await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.SetPolicy(sqs, sns, prefix, endpointName, eventTypes, false, false, new List<string>()));
                         });
-
                     });
 
                     policyCommand.Command("wildcard", policyBasedOnWildcardsCommand =>
@@ -294,7 +293,7 @@
                         };
                         policyBasedOnWildcardsCommand.Options.Add(namespaceOption);
 
-                        policyBasedOnWildcardsCommand.OnExecute(async () =>
+                        policyBasedOnWildcardsCommand.OnExecuteAsync(async ct =>
                         {
                             var endpointName = nameArgument.Value;
                             var addAccountCondition = accountOption.HasValue();
@@ -305,6 +304,25 @@
 
                             await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.SetPolicy(sqs, sns, prefix, endpointName, eventTypes, addAccountCondition, addPrefixcondition, namespaceConditions));
                         });
+                    });
+                });
+                
+                endpointCommand.Command("list-policy", listPolicyCommand =>
+                {
+                    listPolicyCommand.Description = "Sets the IAM policy for an endpoint.";
+                    var nameArgument = listPolicyCommand.Argument("name", "Name of the endpoint (required)").IsRequired();
+
+                    listPolicyCommand.Options.Add(accessKeyOption);
+                    listPolicyCommand.Options.Add(regionOption);                        
+                    listPolicyCommand.Options.Add(secretOption);
+                    listPolicyCommand.Options.Add(prefixOption);
+
+                    listPolicyCommand.OnExecuteAsync(async ct =>
+                    {
+                        var endpointName = nameArgument.Value;
+                        var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;                            
+
+                        await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.ListPolicy(sqs, sns, prefix, endpointName));
                     });
                 });
             

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -8,15 +8,15 @@
     // sqs-transport endpoint create name [--other-options]
     // sqs-transport endpoint add name large-message-support bucket-name [--other-options]
     // sqs-transport endpoint add name delay-delivery-support [--other-options]
-    
+
     // sqs-transport endpoint unsubscribe name event-type [--other-options]
     // sqs-transport endpoint remove large-message-support bucket-name [--other-options]
     // sqs-transport endpoint remove remove delay-delivery-support [--other-options]
     // sqs-transport endpoint delete name [--other-options]
 
     // sqs-transport endpoint subscribe name event-type [--other-options]
-    // sqs-transport endpoint set-policy "endpointname"  events  --event-type "event-type1" --event-type "event-type2" [--other-options]  
-    // sqs-transport endpoint set-policy name wildcard --account-condition --namespace-condition "namespacename" --prefix-condition --prefix "prefix" --remove-event-type "event-type2" [--other-options] 
+    // sqs-transport endpoint set-policy "endpointname"  events  --event-type "event-type1" --event-type "event-type2" [--other-options]
+    // sqs-transport endpoint set-policy name wildcard --account-condition --namespace-condition "namespacename" --prefix-condition --prefix "prefix" --remove-event-type "event-type2" [--other-options]
     // sqs-transport endpoint list-policy name [--other-options]
     class Program
     {
@@ -68,7 +68,8 @@
                     createCommand.Options.Add(secretOption);
                     createCommand.Options.Add(prefixOption);
 
-                    var retentionPeriodInSecondsCommand = createCommand.Option("-t|--retention", "Retention Period in seconds (defaults to " + DefaultConfigurationValues.RetentionPeriod.TotalSeconds + " ) ", CommandOptionType.SingleValue);
+                    var retentionPeriodInSecondsCommand = createCommand.Option("-t|--retention",
+                        $"Retention Period in seconds (defaults to {DefaultConfigurationValues.RetentionPeriod.TotalSeconds} ) ", CommandOptionType.SingleValue);
 
                     createCommand.OnExecuteAsync(async ct =>
                     {
@@ -113,14 +114,15 @@
                         largeMessageSupportCommand.Options.Add(secretOption);
 
                         var keyPrefixCommand = largeMessageSupportCommand.Option("-k|--key-prefix", "S3 Key prefix.", CommandOptionType.SingleValue);
-                        var expirationInDaysCommand = largeMessageSupportCommand.Option("-e|--expiration", "Experation time in days (defaults to " + DefaultConfigurationValues.RetentionPeriod.TotalDays + " ) ", CommandOptionType.SingleValue);
+                        var expirationInDaysCommand = largeMessageSupportCommand.Option("-e|--expiration",
+                            $"Expiration time in days (defaults to {DefaultConfigurationValues.RetentionPeriod.TotalDays} ) ", CommandOptionType.SingleValue);
 
                         largeMessageSupportCommand.OnExecuteAsync(async ct =>
                         {
                             var endpointName = nameArgument.Value;
                             var bucketName = bucketArgument.Value;
                             var keyPrefix = keyPrefixCommand.HasValue() ? keyPrefixCommand.Value() : DefaultConfigurationValues.S3KeyPrefix;
-                            var expirationInDays = expirationInDaysCommand.HasValue() ? int.Parse(expirationInDaysCommand.Value()) : (int)(Math.Ceiling(DefaultConfigurationValues.RetentionPeriod.TotalDays));
+                            var expirationInDays = expirationInDaysCommand.HasValue() ? int.Parse(expirationInDaysCommand.Value()) : (int)Math.Ceiling(DefaultConfigurationValues.RetentionPeriod.TotalDays);
 
                             await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.AddLargeMessageSupport(s3, endpointName, bucketName, keyPrefix, expirationInDays));
                         });
@@ -240,12 +242,12 @@
                         await Console.Out.WriteLineAsync($"Endpoint '{endpointName}' unsubscribed from '{eventType}'.");
                     });
                 });
-            
-                endpointCommand.Command("set-policy", policyCommand => 
+
+                endpointCommand.Command("set-policy", policyCommand =>
                 {
                     policyCommand.Description = "Sets the IAM policy for an endpoint.";
                     var nameArgument = policyCommand.Argument("name", "Name of the endpoint (required)").IsRequired();
-                       
+
                     policyCommand.OnExecute(() =>
                     {
                         Console.WriteLine("Specify a subcommand");
@@ -253,20 +255,20 @@
                         return 1;
                     });
 
-                    policyCommand.Command("events", policyBasedOneventsCommand =>
+                    policyCommand.Command("events", policyBasedOnEventsCommand =>
                     {
-                        policyBasedOneventsCommand.Options.Add(accessKeyOption);
-                        policyBasedOneventsCommand.Options.Add(regionOption);
-                        policyBasedOneventsCommand.Options.Add(secretOption);
-                        policyBasedOneventsCommand.Options.Add(prefixOption);
+                        policyBasedOnEventsCommand.Options.Add(accessKeyOption);
+                        policyBasedOnEventsCommand.Options.Add(regionOption);
+                        policyBasedOnEventsCommand.Options.Add(secretOption);
+                        policyBasedOnEventsCommand.Options.Add(prefixOption);
 
                         var eventTypeOption = new CommandOption("-evt|--event-type", CommandOptionType.MultipleValue)
                         {
                             Description = "Allow subscription to topic for specific event type."
                         };
-                        policyBasedOneventsCommand.Options.Add(eventTypeOption);
+                        policyBasedOnEventsCommand.Options.Add(eventTypeOption);
 
-                        policyBasedOneventsCommand.OnExecuteAsync(async ct =>
+                        policyBasedOnEventsCommand.OnExecuteAsync(async ct =>
                         {
                             var endpointName = nameArgument.Value;
                             var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;
@@ -279,7 +281,7 @@
                     policyCommand.Command("wildcard", policyBasedOnWildcardsCommand =>
                     {
                         policyBasedOnWildcardsCommand.Options.Add(accessKeyOption);
-                        policyBasedOnWildcardsCommand.Options.Add(regionOption);                        
+                        policyBasedOnWildcardsCommand.Options.Add(regionOption);
                         policyBasedOnWildcardsCommand.Options.Add(secretOption);
                         policyBasedOnWildcardsCommand.Options.Add(prefixOption);
 
@@ -299,8 +301,8 @@
                         {
                             Description = "Allow subscription to topics for events in a specific namespace."
                         };
-                        policyBasedOnWildcardsCommand.Options.Add(namespaceWildcardOption);   
-                        
+                        policyBasedOnWildcardsCommand.Options.Add(namespaceWildcardOption);
+
                         var removeEventTypeOption = new CommandOption("-revt|--remove-event-type", CommandOptionType.MultipleValue)
                         {
                             Description = "Remove topic for specific event type."
@@ -311,35 +313,35 @@
                         {
                             var endpointName = nameArgument.Value;
                             var addAccountCondition = accountWildcardOption.HasValue();
-                            var addPrefixcondition = prefixWildcardOption.HasValue();
-                            var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;                            
+                            var addPrefixCondition = prefixWildcardOption.HasValue();
+                            var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;
                             var namespaceConditions = namespaceWildcardOption.HasValue() ? namespaceWildcardOption.Values : new List<string>();
                             var eventTypes = removeEventTypeOption.HasValue() ? removeEventTypeOption.Values : new List<string>();
 
-                            await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.SetPolicy(sqs, sns, prefix, endpointName, eventTypes, addAccountCondition, addPrefixcondition, namespaceConditions));
+                            await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.SetPolicy(sqs, sns, prefix, endpointName, eventTypes, addAccountCondition, addPrefixCondition, namespaceConditions));
                         });
                     });
                 });
-                
+
                 endpointCommand.Command("list-policy", listPolicyCommand =>
                 {
                     listPolicyCommand.Description = "Sets the IAM policy for an endpoint.";
                     var nameArgument = listPolicyCommand.Argument("name", "Name of the endpoint (required)").IsRequired();
 
                     listPolicyCommand.Options.Add(accessKeyOption);
-                    listPolicyCommand.Options.Add(regionOption);                        
+                    listPolicyCommand.Options.Add(regionOption);
                     listPolicyCommand.Options.Add(secretOption);
                     listPolicyCommand.Options.Add(prefixOption);
 
                     listPolicyCommand.OnExecuteAsync(async ct =>
                     {
                         var endpointName = nameArgument.Value;
-                        var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;                            
+                        var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;
 
                         await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.ListPolicy(sqs, sns, prefix, endpointName));
                     });
                 });
-            
+
             });
 
             app.OnExecute(() =>

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -13,7 +13,7 @@
     // sqs-transport endpoint remove large-message-support bucket-name [--other-options]
     // sqs-transport endpoint remove remove delay-delivery-support [--other-options]
     // sqs-transport endpoint delete name [--other-options]
-    // sqs-transport endpoint set-policy name wildcard --account --namespace "namespacename" --prefix "prefix" [--other-options] 
+    // sqs-transport endpoint set-policy name wildcard --account-wildcard --namespace "namespacename" --prefix "prefix" [--other-options] 
     // sqs-transport endpoint set-policy name events --event-type "event-type1" --event-type "event-type2" [--other-options] 
     // sqs-transport endpoint list-policy name [--other-options]
     class Program
@@ -281,25 +281,31 @@
                         policyBasedOnWildcardsCommand.Options.Add(secretOption);
                         policyBasedOnWildcardsCommand.Options.Add(prefixOption);
 
-                        var accountOption = new CommandOption("-a|--account", CommandOptionType.NoValue)
+                        var accountWildcardOption = new CommandOption("-aw|--account-wildcard", CommandOptionType.NoValue)
                         {
                             Description = "Allow subscription to all topics in an account."
                         };
-                        policyBasedOnWildcardsCommand.Options.Add(accountOption);
+                        policyBasedOnWildcardsCommand.Options.Add(accountWildcardOption);
 
-                        var namespaceOption = new CommandOption("-n|--namespace", CommandOptionType.MultipleValue)
+                        var prefixWildcardOption = new CommandOption("-nw|--prefix-wildcard", CommandOptionType.NoValue)
+                        {
+                            Description = "Allow subscription to topics with a specific wildcard."
+                        };
+                        policyBasedOnWildcardsCommand.Options.Add(prefixWildcardOption);
+
+                        var namespaceWildcardOption = new CommandOption("-nw|--namespace-wildcard", CommandOptionType.MultipleValue)
                         {
                             Description = "Allow subscription to topics for events in a specific namespace."
                         };
-                        policyBasedOnWildcardsCommand.Options.Add(namespaceOption);
+                        policyBasedOnWildcardsCommand.Options.Add(namespaceWildcardOption);                        
 
                         policyBasedOnWildcardsCommand.OnExecuteAsync(async ct =>
                         {
                             var endpointName = nameArgument.Value;
-                            var addAccountCondition = accountOption.HasValue();
-                            var addPrefixcondition = prefixOption.HasValue();
-                            var prefix = addPrefixcondition ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;                            
-                            var namespaceConditions = namespaceOption.HasValue() ? namespaceOption.Values : new List<string>();
+                            var addAccountCondition = accountWildcardOption.HasValue();
+                            var addPrefixcondition = prefixWildcardOption.HasValue();
+                            var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;                            
+                            var namespaceConditions = namespaceWildcardOption.HasValue() ? namespaceWildcardOption.Values : new List<string>();
                             var eventTypes = new List<string>();
 
                             await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.SetPolicy(sqs, sns, prefix, endpointName, eventTypes, addAccountCondition, addPrefixcondition, namespaceConditions));

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -13,7 +13,7 @@
     // sqs-transport endpoint remove large-message-support bucket-name [--other-options]
     // sqs-transport endpoint remove remove delay-delivery-support [--other-options]
     // sqs-transport endpoint delete name [--other-options]
-    // sqs-transport endpoint set-policy name wildcard --account-wildcard --namespace "namespacename" --prefix "prefix" [--other-options] 
+    // sqs-transport endpoint set-policy name wildcard --account-wildcard --namespace "namespacename" --prefix "prefix" --remove-event-type "event-type2" [--other-options] 
     // sqs-transport endpoint set-policy name events --event-type "event-type1" --event-type "event-type2" [--other-options] 
     // sqs-transport endpoint list-policy name [--other-options]
     class Program
@@ -297,7 +297,13 @@
                         {
                             Description = "Allow subscription to topics for events in a specific namespace."
                         };
-                        policyBasedOnWildcardsCommand.Options.Add(namespaceWildcardOption);                        
+                        policyBasedOnWildcardsCommand.Options.Add(namespaceWildcardOption);   
+                        
+                        var removeEventTypeOption = new CommandOption("-revt|--remove-event-type", CommandOptionType.MultipleValue)
+                        {
+                            Description = "Remove topic for specific event type."
+                        };
+                        policyBasedOnWildcardsCommand.Options.Add(removeEventTypeOption);
 
                         policyBasedOnWildcardsCommand.OnExecuteAsync(async ct =>
                         {
@@ -306,7 +312,7 @@
                             var addPrefixcondition = prefixWildcardOption.HasValue();
                             var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;                            
                             var namespaceConditions = namespaceWildcardOption.HasValue() ? namespaceWildcardOption.Values : new List<string>();
-                            var eventTypes = new List<string>();
+                            var eventTypes = removeEventTypeOption.HasValue() ? removeEventTypeOption.Values : new List<string>();
 
                             await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.SetPolicy(sqs, sns, prefix, endpointName, eventTypes, addAccountCondition, addPrefixcondition, namespaceConditions));
                         });

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -281,7 +281,7 @@
                         policyBasedOnWildcardsCommand.Options.Add(secretOption);
                         policyBasedOnWildcardsCommand.Options.Add(prefixOption);
 
-                        var accountOption = new CommandOption("-a|--account", CommandOptionType.SingleValue)
+                        var accountOption = new CommandOption("-a|--account", CommandOptionType.NoValue)
                         {
                             Description = "Allow subscription to all topics in an account."
                         };

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -8,13 +8,15 @@
     // sqs-transport endpoint create name [--other-options]
     // sqs-transport endpoint add name large-message-support bucket-name [--other-options]
     // sqs-transport endpoint add name delay-delivery-support [--other-options]
-    // sqs-transport endpoint subscribe name event-type [--other-options]
+    
     // sqs-transport endpoint unsubscribe name event-type [--other-options]
     // sqs-transport endpoint remove large-message-support bucket-name [--other-options]
     // sqs-transport endpoint remove remove delay-delivery-support [--other-options]
     // sqs-transport endpoint delete name [--other-options]
-    // sqs-transport endpoint set-policy name wildcard --account-wildcard --namespace "namespacename" --prefix "prefix" --remove-event-type "event-type2" [--other-options] 
-    // sqs-transport endpoint set-policy name events --event-type "event-type1" --event-type "event-type2" [--other-options] 
+
+    // sqs-transport endpoint subscribe name event-type [--other-options]
+    // sqs-transport endpoint set-policy "endpointname"  events  --event-type "event-type1" --event-type "event-type2" [--other-options]  
+    // sqs-transport endpoint set-policy name wildcard --account-condition --namespace-condition "namespacename" --prefix-condition --prefix "prefix" --remove-event-type "event-type2" [--other-options] 
     // sqs-transport endpoint list-policy name [--other-options]
     class Program
     {
@@ -281,19 +283,19 @@
                         policyBasedOnWildcardsCommand.Options.Add(secretOption);
                         policyBasedOnWildcardsCommand.Options.Add(prefixOption);
 
-                        var accountWildcardOption = new CommandOption("-aw|--account-wildcard", CommandOptionType.NoValue)
+                        var accountWildcardOption = new CommandOption("-ac|--account-condition", CommandOptionType.NoValue)
                         {
                             Description = "Allow subscription to all topics in an account."
                         };
                         policyBasedOnWildcardsCommand.Options.Add(accountWildcardOption);
 
-                        var prefixWildcardOption = new CommandOption("-nw|--prefix-wildcard", CommandOptionType.NoValue)
+                        var prefixWildcardOption = new CommandOption("-pc|--prefix-condition", CommandOptionType.NoValue)
                         {
                             Description = "Allow subscription to topics with a specific wildcard."
                         };
                         policyBasedOnWildcardsCommand.Options.Add(prefixWildcardOption);
 
-                        var namespaceWildcardOption = new CommandOption("-nw|--namespace-wildcard", CommandOptionType.MultipleValue)
+                        var namespaceWildcardOption = new CommandOption("-nc|--namespace-condition", CommandOptionType.MultipleValue)
                         {
                             Description = "Allow subscription to topics for events in a specific namespace."
                         };

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -12,6 +12,8 @@
     // sqs-transport endpoint remove large-message-support bucket-name [--other-options]
     // sqs-transport endpoint remove remove delay-delivery-support [--other-options]
     // sqs-transport endpoint delete name [--other-options]
+    // sqs-transport endpoint policy wildcard --account --namespace "namespacename" --prefix "prefix" [--other-options] 
+    // sqs-transport endpoint policy events --event-type "event-type1" --event-type "event-type2" [--other-options] 
     class Program
     {
         static int Main(string[] args)
@@ -234,6 +236,66 @@
                         await Console.Out.WriteLineAsync($"Endpoint '{endpointName}' unsubscribed from '{eventType}'.");
                     });
                 });
+            
+                endpointCommand.Command("policy", policyCommand => 
+                {
+                    policyCommand.Description = "Sets the IAM policy for an endpoint.";
+
+                    policyCommand.OnExecute(() =>
+                    {
+                        Console.WriteLine("Specify a subcommand");
+                        policyCommand.ShowHelp();
+                        return 1;
+                    });
+
+                    policyCommand.Command("events", policyBasedOneventsCommand =>
+                    {
+                        policyBasedOneventsCommand.Options.Add(accessKeyOption);
+                        policyBasedOneventsCommand.Options.Add(regionOption);
+                        policyBasedOneventsCommand.Options.Add(secretOption);
+                        policyBasedOneventsCommand.Options.Add(prefixOption);
+
+                        var eventTypeOption = new CommandOption("-evt|--event-type", CommandOptionType.MultipleValue)
+                        {
+                            Description = "Allow subscription to topic for specific event type."
+                        };
+                        policyBasedOneventsCommand.Options.Add(eventTypeOption);
+
+                        policyBasedOneventsCommand.OnExecute(() =>
+                        {
+                            // TODO
+                            return 1;
+                        });
+
+                    });
+
+                    policyCommand.Command("wildcard", policyBasedOnWildcardsCommand =>
+                    {
+                        policyBasedOnWildcardsCommand.Options.Add(accessKeyOption);
+                        policyBasedOnWildcardsCommand.Options.Add(regionOption);
+                        policyBasedOnWildcardsCommand.Options.Add(secretOption);
+                        policyBasedOnWildcardsCommand.Options.Add(prefixOption);
+
+                        var accountOption = new CommandOption("-a|--account", CommandOptionType.SingleValue)
+                        {
+                            Description = "Allow subscription to all topics in an account."
+                        };
+                        policyBasedOnWildcardsCommand.Options.Add(accountOption);
+
+                        var namespaceOption = new CommandOption("-n|--namespace", CommandOptionType.MultipleValue)
+                        {
+                            Description = "Allow subscription to topics for events in a specific namespace."
+                        };
+                        policyBasedOnWildcardsCommand.Options.Add(namespaceOption);
+
+                        policyBasedOnWildcardsCommand.OnExecute(() =>
+                        {
+                            // TODO
+                            return 1;
+                        });
+                    });
+                });
+            
             });
 
             app.OnExecute(() =>

--- a/src/CommandLine/Properties/launchSettings.json
+++ b/src/CommandLine/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NServiceBus.Transports.SQS.CommandLine": {
       "commandName": "Project",
-      "commandLineArgs": "endpoint list-policy test --prefix yves-"
+      "commandLineArgs": "endpoint set-policy test wildcard --account --prefix yves-"
     }
   }
 }

--- a/src/CommandLine/Properties/launchSettings.json
+++ b/src/CommandLine/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NServiceBus.Transports.SQS.CommandLine": {
       "commandName": "Project",
-      "commandLineArgs": "endpoint create test --prefix yves-"
+      "commandLineArgs": "endpoint list-policy test --prefix yves-"
     }
   }
 }

--- a/src/CommandLine/Properties/launchSettings.json
+++ b/src/CommandLine/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NServiceBus.Transports.SQS.CommandLine": {
       "commandName": "Project",
-      "commandLineArgs": "endpoint set-policy test wildcard --account-wildcard --prefix yves-"
+      "commandLineArgs": "endpoint set-policy test2 events --event-type MyMessages.Message35 --prefix yves-"
     }
   }
 }

--- a/src/CommandLine/Properties/launchSettings.json
+++ b/src/CommandLine/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "NServiceBus.Transports.SQS.CommandLine": {
       "commandName": "Project",
-      "commandLineArgs": "endpoint set-policy test wildcard --account --prefix yves-"
+      "commandLineArgs": "endpoint set-policy test wildcard --account-wildcard --prefix yves-"
     }
   }
 }

--- a/src/CommandLine/Topic.cs
+++ b/src/CommandLine/Topic.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.SQS.CommandLine
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Amazon.SimpleNotificationService;
     using Amazon.SimpleNotificationService.Model;
@@ -26,20 +27,25 @@
             return createTopicResponse.TopicArn;
         }
 
-        public static async Task<string> Subscribe(IAmazonSQS sqs, IAmazonSimpleNotificationService sns, string topicArn, string queueUrl)
+        public static async Task<string> Subscribe(IAmazonSQS sqs, IAmazonSimpleNotificationService sns, string topicArn, string queueArn)
         {
-            await Console.Out.WriteLineAsync($"Subscribing queue with url '{queueUrl}' to topic with ARN '{topicArn}'.");
-            var createdSubscription = await sns.SubscribeQueueAsync(topicArn, sqs, queueUrl).ConfigureAwait(false);
-            await Console.Out.WriteLineAsync($"Queue with url '{queueUrl}' subscribed to topic with ARN '{topicArn}'.");
-            await Console.Out.WriteLineAsync($"Setting raw delivery for subscription with arn '{createdSubscription}'.");
-            await sns.SetSubscriptionAttributesAsync(new SetSubscriptionAttributesRequest
+            await Console.Out.WriteLineAsync($"Subscribing queue with ARN '{queueArn}' to topic with ARN '{topicArn}'.");
+
+            var createdSubscription = await sns.SubscribeAsync(new SubscribeRequest
             {
-                SubscriptionArn = createdSubscription,
-                AttributeName = "RawMessageDelivery",
-                AttributeValue = "true"
+                TopicArn = topicArn,
+                Protocol = "sqs",
+                Endpoint = queueArn,
+                ReturnSubscriptionArn = true,
+                Attributes = new Dictionary<string, string>
+                {
+                    { "RawMessageDelivery", "true" }
+                }
             }).ConfigureAwait(false);
-            await Console.Out.WriteLineAsync($"Raw delivery for subscription with arn '{createdSubscription}' set.");
-            return createdSubscription;
+            
+            await Console.Out.WriteLineAsync($"Queue with ARN '{queueArn}' subscribed to topic with ARN '{topicArn}'.");
+
+            return createdSubscription.SubscriptionArn;
         }
 
         public static async Task Unsubscribe(IAmazonSimpleNotificationService sns, string topicArn, string queueArn)

--- a/src/CommandLine/Topic.cs
+++ b/src/CommandLine/Topic.cs
@@ -14,7 +14,7 @@
             var topicName = $"{prefix}{eventType}";
             var sanitized = TopicSanitization.GetSanitizedTopicName(topicName);
             var findTopicResponse = await sns.FindTopicAsync(sanitized).ConfigureAwait(false);
-            return findTopicResponse.TopicArn;
+            return findTopicResponse?.TopicArn;
         }
 
         public static async Task<string> Create(IAmazonSimpleNotificationService sns, string prefix, string eventType)

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -1,11 +1,10 @@
-﻿using System.Text;
-
-namespace NServiceBus.Transport.SQS.CommandLine.Tests
+﻿namespace NServiceBus.Transport.SQS.CommandLine.Tests
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Amazon;
@@ -312,7 +311,7 @@ namespace NServiceBus.Transport.SQS.CommandLine.Tests
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);
             
-            (output, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --account-wildcard --prefix {prefix}");
+            (output, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --account-condition --prefix {prefix}");
 
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);
@@ -328,7 +327,7 @@ namespace NServiceBus.Transport.SQS.CommandLine.Tests
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);
             
-            (output, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --prefix-wildcard --prefix {prefix}");
+            (output, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --prefix-condition --prefix {prefix}");
 
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);
@@ -346,7 +345,7 @@ namespace NServiceBus.Transport.SQS.CommandLine.Tests
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);
             
-            (output, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --namespace-wildcard {ns} --prefix {prefix}");
+            (output, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --namespace-condition {ns} --prefix {prefix}");
 
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);
@@ -377,7 +376,7 @@ namespace NServiceBus.Transport.SQS.CommandLine.Tests
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);
 
-            (_, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --account-wildcard --remove-event-type {EventType} --remove-event-type {EventType2} --prefix {prefix}");
+            (_, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} wildcard --account-condition --remove-event-type {EventType} --remove-event-type {EventType2} --prefix {prefix}");
 
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(error == string.Empty);

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -242,6 +242,33 @@
 
             await VerifyPolicyContainsTopicFor(EndpointName, prefix, EventType);
         }
+        
+        [Test]
+        public async Task Set_policy_multiple_events()
+        {
+            var (_, error, exitCode) = await Execute($"endpoint create {EndpointName} --prefix {prefix}");
+
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+            
+            (_, error, exitCode) = await Execute($"endpoint subscribe {EndpointName} {EventType} --prefix {prefix}");
+            
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+            
+            (_, error, exitCode) = await Execute($"endpoint subscribe {EndpointName} {EventType2} --prefix {prefix}");
+
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+
+            (_, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} events --event-type {EventType} --event-type {EventType2} --prefix {prefix}");
+
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+
+            await VerifyPolicyContainsTopicFor(EndpointName, prefix, EventType);
+            await VerifyPolicyContainsTopicFor(EndpointName, prefix, EventType2);
+        }
 
         [Test]
         public async Task Unsubscribe_from_event_with_remove_shared_resources()
@@ -708,6 +735,7 @@
         const string EndpointName = "nsb-cli-test";
         const string BucketName = "nsb-cli-test-bucket";
         const string EventType = "MyNamespace.MyMessage1";
+        const string EventType2 = "MyNamespace.MyMessage2";
         const int verificationBackoffInterval = 200;
         const int maximumBackoffInterval = 20000; // totals up to 77000
     }

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -206,6 +206,22 @@ namespace NServiceBus.Transport.SQS.CommandLine.Tests
             await VerifySubscriptionDeleted(topicArn, queueArn);
             await VerifyTopic(EventType, prefix);
         }
+        
+        [Test]
+        public async Task Unsubscribe_from_event_without_topic_warns()
+        {
+            var (output, error, exitCode) = await Execute($"endpoint create {EndpointName} --prefix {prefix}");
+
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+
+            (output, error, exitCode) = await Execute($"endpoint unsubscribe {EndpointName} {EventType} --prefix {prefix}");
+
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+            
+            Assert.IsTrue(output.Contains($"No topic detected for event type '{EventType}', please subscribe to the event type first."));
+        }
 
         [Test]
         public async Task List_policy()
@@ -243,6 +259,22 @@ namespace NServiceBus.Transport.SQS.CommandLine.Tests
             Assert.IsTrue(error == string.Empty);
 
             await VerifyPolicyContainsTopicFor(EndpointName, prefix, EventType);
+        }
+        
+        [Test]
+        public async Task Set_policy_single_event_without_subscribe_warns()
+        {
+            var (output, error, exitCode) = await Execute($"endpoint create {EndpointName} --prefix {prefix}");
+
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+            
+            (output, error, exitCode) = await Execute($"endpoint set-policy {EndpointName} events --event-type {EventType} --prefix {prefix}");
+
+            Assert.AreEqual(0, exitCode);
+            Assert.IsTrue(error == string.Empty);
+
+            Assert.IsTrue(output.Contains($"No topic detected for event type '{EventType}', please subscribe to the event type first."));
         }
         
         [Test]

--- a/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.111.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.103.15" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.102.5" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.7.6" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.8" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.30" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
@@ -35,6 +35,6 @@
       <Link>Cleanup.cs</Link>
     </Compile>
     <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
-  </ItemGroup>  
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
CLI changes related to https://github.com/Particular/NServiceBus.AmazonSQS/pull/601

Introduces 3 new commands

> sqs-transport endpoint set-policy  "endpointname" events --event-type "event-type1" --event-type "event-type2" [--other-options] 

> sqs-transport endpoint set-policy "endpointname" wildcard --account-wildcard --namespace "namespacename" --prefix "prefix" --remove-event-type "event-type1"  --remove-event-type "event-type2"  [--other-options] 

> sqs-transport endpoint list-policy  "endpointname" [--other-options]

Changed the behavior of subscribe to no longer auto create policy

> sqs-transport endpoint subscribe name event-type [--other-options]
