### PR TITLE
Manual subscribe after settle

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/SubscriptionManagerTests.Subscribe_after_settle_sets_full_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/SubscriptionManagerTests.Subscribe_after_settle_sets_full_policy.approved.txt
@@ -1,0 +1,22 @@
+{
+    "Version" : "2012-10-17",
+    "Statement" : [
+        {
+            "Effect" : "Allow",
+            "Principal" : {
+                "AWS" : "*"
+            },
+            "Action"    : "sqs:SendMessage",
+            "Resource"  : "arn:fakeQueue",
+            "Condition" : {
+                "ArnLike" : {
+                    "aws:SourceArn" : [
+                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event",
+                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-YetAnotherEvent"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/src/NServiceBus.Transport.SQS/SubscriptionManager.cs
+++ b/src/NServiceBus.Transport.SQS/SubscriptionManager.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Transport.SQS
                 .ConfigureAwait(false);
 
             // currently we are not doing fanout but better safe than sorry later
-            var policyStatementsToBeSettled = new ConcurrentBag<PolicyStatement>();
+            var policyStatementsToBeSettled = new ConcurrentBag<PolicyStatement>(settledPolicyStatements);
 
             var metadata = messageMetadataRegistry.GetMessageMetadata(eventType);
             await SetupTypeSubscriptions(metadata, queueUrl, policyStatementsToBeSettled).ConfigureAwait(false);
@@ -75,8 +75,9 @@ namespace NServiceBus.Transport.SQS
             // unfortunately there is no clear
             while (!preparedPolicyStatements.IsEmpty)
             {
-                if (preparedPolicyStatements.TryTake(out _))
+                if (preparedPolicyStatements.TryTake(out var policyStatement))
                 {
+                    settledPolicyStatements.Add(policyStatement);
                 }
             }
 
@@ -316,6 +317,7 @@ namespace NServiceBus.Transport.SQS
 
         readonly ConcurrentDictionary<Type, string> typeTopologyConfiguredSet = new ConcurrentDictionary<Type, string>();
         readonly ConcurrentBag<PolicyStatement> preparedPolicyStatements = new ConcurrentBag<PolicyStatement>();
+        readonly List<PolicyStatement> settledPolicyStatements = new List<PolicyStatement>();
         readonly QueueCache queueCache;
         readonly IAmazonSQS sqsClient;
         readonly IAmazonSimpleNotificationService snsClient;


### PR DESCRIPTION
Makes sure subscribe after settle works properly and takes all auto-subscribed events into account for the full picture