### PR TITLE
Remove BCL interfaces again

### DIFF
--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.0.10" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.0.10" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Particular.Packaging" Version="1.2.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Previously we had build failures when building on windows and then restoring dependencies on linux. As a workaround, we added BCL interfaces. Since we now build on both OS this is no longer needed.

Background https://github.com/Particular/NServiceBus.AmazonSQS/pull/718