### PR TITLE
fix OCE catching, Task.Run, etc.

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.7.0.17" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1892" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1895" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/NativeEndpoint.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/NativeEndpoint.cs
@@ -20,8 +20,10 @@
                     QueueName = TestNameHelper.GetSqsQueueName(errorQueueAddress, SetupFixture.NamePrefix)
                 }, cancellationToken).ConfigureAwait(false);
 
-                while (!cancellationToken.IsCancellationRequested)
+                while (true)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     var receiveMessageResponse = await sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
                     {
                         QueueUrl = getQueueUrlResponse.QueueUrl,

--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -83,9 +83,7 @@ namespace NServiceBus.Transport.SQS.Tests
                 Body = null //poison message
             };
 
-            var semaphore = new SemaphoreSlim(0, 1);
-
-            await pump.ProcessMessage(message, semaphore).ConfigureAwait(false);
+            await pump.ProcessMessage(message, CancellationToken.None).ConfigureAwait(false);
 
             Assert.IsFalse(processed);
             Assert.AreEqual(1, mockSqsClient.RequestsSent.Count);
@@ -133,9 +131,7 @@ namespace NServiceBus.Transport.SQS.Tests
                 Body = json
             };
 
-            var semaphore = new SemaphoreSlim(0, 1);
-
-            await pump.ProcessMessage(message, semaphore).ConfigureAwait(false);
+            await pump.ProcessMessage(message, CancellationToken.None).ConfigureAwait(false);
 
             Assert.IsFalse(processed);
             Assert.AreEqual(1, mockSqsClient.DeleteMessageRequestsSent.Count);
@@ -176,9 +172,7 @@ namespace NServiceBus.Transport.SQS.Tests
                 Body = json
             };
 
-            var semaphore = new SemaphoreSlim(0, 1);
-
-            await pump.ProcessMessage(message, semaphore).ConfigureAwait(false);
+            await pump.ProcessMessage(message, CancellationToken.None).ConfigureAwait(false);
 
             Assert.IsTrue(processed);
             Assert.AreEqual(1, mockSqsClient.DeleteMessageRequestsSent.Count);

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1891" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1895" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.7.0.17" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.1891" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.1895" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_poison_messages.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_poison_messages.cs
@@ -71,8 +71,10 @@
                 var messageReceived = false;
                 ReceiveMessageResponse receiveMessageResponse = null;
 
-                while (messageReceived == false && !cancellationToken.IsCancellationRequested)
+                while (messageReceived == false)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     receiveMessageResponse = await sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
                     {
                         QueueUrl = getQueueUrlResponse.QueueUrl,

--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_poison_messages.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_poison_messages.cs
@@ -71,7 +71,7 @@
                 var messageReceived = false;
                 ReceiveMessageResponse receiveMessageResponse = null;
 
-                while (messageReceived == false)
+                while (!messageReceived)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/NServiceBus.Transport.SQS/ExceptionExtensions.cs
+++ b/src/NServiceBus.Transport.SQS/ExceptionExtensions.cs
@@ -1,0 +1,12 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading;
+
+    static class ExceptionExtensions
+    {
+#pragma warning disable PS0003 // A parameter of type CancellationToken on a non-private delegate or method should be optional
+        public static bool IsCausedBy(this Exception ex, CancellationToken cancellationToken) => ex is OperationCanceledException && cancellationToken.IsCancellationRequested;
+#pragma warning restore PS0003 // A parameter of type CancellationToken on a non-private delegate or method should be optional
+    }
+}

--- a/src/NServiceBus.Transport.SQS/Extensions/AmazonServiceExtensions.cs
+++ b/src/NServiceBus.Transport.SQS/Extensions/AmazonServiceExtensions.cs
@@ -18,6 +18,8 @@
 
             while (true)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 try
                 {
                     tryCount++;

--- a/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
@@ -62,9 +62,9 @@
             {
                 await Task.WhenAll(concurrentDispatchTasks).ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
-                Logger.Error("Exception from Send.", e);
+                Logger.Error("Exception from Send.", ex);
                 throw;
             }
         }
@@ -162,7 +162,7 @@
                 Logger.Error($"Error while sending batch '{batchNumber}/{totalBatches}', with message ids '{string.Join(", ", batch.PreparedMessagesBydId.Values.Select(v => v.MessageId))}', to '{message.Destination}'. The destination does not exist.", e);
                 throw;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
                 var message = batch.PreparedMessagesBydId.Values.First();
 
@@ -233,7 +233,7 @@
             {
                 throw new QueueDoesNotExistException($"Destination '{message.OriginalDestination}' doesn't support delayed messages longer than {TimeSpan.FromSeconds(queueDelaySeconds)}. To enable support for longer delays upgrade '{message.OriginalDestination}' endpoint to Version 6 of the transport or enable unrestricted delayed delivery.", e);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsCausedBy(cancellationToken))
             {
                 Logger.Error($"Error while sending message, with MessageId '{message.MessageId}', to '{message.Destination}'", ex);
                 throw;

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AWSSDK.S3" Version="[3.7, 3.8)" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7, 3.8)" />
     <PackageReference Include="AWSSDK.SQS" Version="[3.7, 3.8)" />
-    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1891, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1895, 9.0.0)" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.SQS/QueueCreator.cs
+++ b/src/NServiceBus.Transport.SQS/QueueCreator.cs
@@ -26,86 +26,84 @@
 
         public async Task CreateQueueIfNecessary(string address, bool createDelayedDeliveryQueue, CancellationToken cancellationToken = default)
         {
-            try
+            var queueName = address;
+            var delayDeliveryQueuePhysicalAddress = queueCache.GetPhysicalQueueName(queueName);
+            var sqsRequest = new CreateQueueRequest
             {
-                var queueName = address;
-                var delayDeliveryQueuePhysicalAddress = queueCache.GetPhysicalQueueName(queueName);
-                var sqsRequest = new CreateQueueRequest
+                QueueName = delayDeliveryQueuePhysicalAddress
+            };
+
+            Logger.Info($"Creating SQS Queue with name '{sqsRequest.QueueName}' for address '{queueName}'.");
+            var createQueueResponse = await sqsClient.CreateQueueAsync(sqsRequest, cancellationToken).ConfigureAwait(false);
+
+            queueCache.SetQueueUrl(queueName, createQueueResponse.QueueUrl);
+
+            // Set the queue attributes in a separate call.
+            // If you call CreateQueue with a queue name that already exists, and with a different
+            // value for MessageRetentionPeriod, the service throws. This will happen if you
+            // change the MaxTTLDays configuration property.
+            var sqsAttributesRequest = new SetQueueAttributesRequest
+            {
+                QueueUrl = createQueueResponse.QueueUrl
+            };
+            sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod,
+                maxTimeToLive.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+
+            await sqsClient.SetQueueAttributesAsync(sqsAttributesRequest, cancellationToken).ConfigureAwait(false);
+
+            if (createDelayedDeliveryQueue)
+            {
+                var delayedDeliveryQueueName = $"{queueName}{TransportConstraints.DelayedDeliveryQueueSuffix}";
+                delayDeliveryQueuePhysicalAddress = queueCache.GetPhysicalQueueName(delayedDeliveryQueueName);
+                sqsRequest = new CreateQueueRequest
                 {
-                    QueueName = delayDeliveryQueuePhysicalAddress
+                    QueueName = delayDeliveryQueuePhysicalAddress,
+                    Attributes = new Dictionary<string, string> { { "FifoQueue", "true" } }
                 };
 
-                Logger.Info($"Creating SQS Queue with name '{sqsRequest.QueueName}' for address '{queueName}'.");
-                var createQueueResponse = await sqsClient.CreateQueueAsync(sqsRequest, cancellationToken).ConfigureAwait(false);
+                Logger.Info($"Creating SQS delayed delivery queue with name '{sqsRequest.QueueName}' for address '{address}'.");
+                createQueueResponse = await sqsClient.CreateQueueAsync(sqsRequest, cancellationToken).ConfigureAwait(false);
 
-                queueCache.SetQueueUrl(queueName, createQueueResponse.QueueUrl);
+                queueCache.SetQueueUrl(delayedDeliveryQueueName, createQueueResponse.QueueUrl);
 
-                // Set the queue attributes in a separate call.
-                // If you call CreateQueue with a queue name that already exists, and with a different
-                // value for MessageRetentionPeriod, the service throws. This will happen if you
-                // change the MaxTTLDays configuration property.
-                var sqsAttributesRequest = new SetQueueAttributesRequest
+                sqsAttributesRequest = new SetQueueAttributesRequest
                 {
                     QueueUrl = createQueueResponse.QueueUrl
                 };
-                sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod,
-                    maxTimeToLive.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+
+                sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod, TransportConstraints.DelayedDeliveryQueueMessageRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+                sqsAttributesRequest.Attributes.Add(QueueAttributeName.DelaySeconds, queueDelaySeconds.ToString(CultureInfo.InvariantCulture));
 
                 await sqsClient.SetQueueAttributesAsync(sqsAttributesRequest, cancellationToken).ConfigureAwait(false);
+            }
 
-                if (createDelayedDeliveryQueue)
+            if (s3Settings != null)
+            {
+                // determine if the configured bucket exists; create it if it doesn't
+                var listBucketsResponse = await s3Settings.S3Client.ListBucketsAsync(new ListBucketsRequest(), cancellationToken).ConfigureAwait(false);
+                var bucketExists = listBucketsResponse.Buckets.Any(x => string.Equals(x.BucketName, s3Settings.BucketName, StringComparison.InvariantCultureIgnoreCase));
+                if (!bucketExists)
                 {
-                    var delayedDeliveryQueueName = $"{queueName}{TransportConstraints.DelayedDeliveryQueueSuffix}";
-                    delayDeliveryQueuePhysicalAddress = queueCache.GetPhysicalQueueName(delayedDeliveryQueueName);
-                    sqsRequest = new CreateQueueRequest
-                    {
-                        QueueName = delayDeliveryQueuePhysicalAddress,
-                        Attributes = new Dictionary<string, string> { { "FifoQueue", "true" } }
-                    };
-
-                    Logger.Info($"Creating SQS delayed delivery queue with name '{sqsRequest.QueueName}' for address '{address}'.");
-                    createQueueResponse = await sqsClient.CreateQueueAsync(sqsRequest, cancellationToken).ConfigureAwait(false);
-
-                    queueCache.SetQueueUrl(delayedDeliveryQueueName, createQueueResponse.QueueUrl);
-
-                    sqsAttributesRequest = new SetQueueAttributesRequest
-                    {
-                        QueueUrl = createQueueResponse.QueueUrl
-                    };
-
-                    sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod, TransportConstraints.DelayedDeliveryQueueMessageRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture));
-                    sqsAttributesRequest.Attributes.Add(QueueAttributeName.DelaySeconds, queueDelaySeconds.ToString(CultureInfo.InvariantCulture));
-
-                    await sqsClient.SetQueueAttributesAsync(sqsAttributesRequest, cancellationToken).ConfigureAwait(false);
+                    await s3Settings.S3Client.RetryConflictsAsync(async token =>
+                            await s3Settings.S3Client.PutBucketAsync(new PutBucketRequest
+                            {
+                                BucketName = s3Settings.BucketName
+                            }, token).ConfigureAwait(false), onRetry: x => { Logger.Warn($"Conflict when creating S3 bucket, retrying after {x}ms."); }, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
 
-                if (s3Settings != null)
+                var lifecycleConfig = await s3Settings.S3Client.GetLifecycleConfigurationAsync(s3Settings.BucketName, cancellationToken).ConfigureAwait(false);
+                var setLifecycleConfig = lifecycleConfig.Configuration.Rules.All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
+
+                if (setLifecycleConfig)
                 {
-                    // determine if the configured bucket exists; create it if it doesn't
-                    var listBucketsResponse = await s3Settings.S3Client.ListBucketsAsync(new ListBucketsRequest(), cancellationToken).ConfigureAwait(false);
-                    var bucketExists = listBucketsResponse.Buckets.Any(x => string.Equals(x.BucketName, s3Settings.BucketName, StringComparison.InvariantCultureIgnoreCase));
-                    if (!bucketExists)
-                    {
-                        await s3Settings.S3Client.RetryConflictsAsync(async token =>
-                                await s3Settings.S3Client.PutBucketAsync(new PutBucketRequest
+                    await s3Settings.S3Client.RetryConflictsAsync(async token =>
+                            await s3Settings.S3Client.PutLifecycleConfigurationAsync(new PutLifecycleConfigurationRequest
+                            {
+                                BucketName = s3Settings.BucketName,
+                                Configuration = new LifecycleConfiguration
                                 {
-                                    BucketName = s3Settings.BucketName
-                                }, token).ConfigureAwait(false), onRetry: x => { Logger.Warn($"Conflict when creating S3 bucket, retrying after {x}ms."); }, cancellationToken: cancellationToken).ConfigureAwait(false);
-                    }
-
-                    var lifecycleConfig = await s3Settings.S3Client.GetLifecycleConfigurationAsync(s3Settings.BucketName, cancellationToken).ConfigureAwait(false);
-                    var setLifecycleConfig = lifecycleConfig.Configuration.Rules.All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
-
-                    if (setLifecycleConfig)
-                    {
-                        await s3Settings.S3Client.RetryConflictsAsync(async token =>
-                                await s3Settings.S3Client.PutLifecycleConfigurationAsync(new PutLifecycleConfigurationRequest
-                                {
-                                    BucketName = s3Settings.BucketName,
-                                    Configuration = new LifecycleConfiguration
+                                    Rules = new List<LifecycleRule>
                                     {
-                                        Rules = new List<LifecycleRule>
-                                        {
                                             new LifecycleRule
                                             {
                                                 Id = "NServiceBus.SQS.DeleteMessageBodies",
@@ -122,16 +120,10 @@
                                                     Days = (int)Math.Ceiling(maxTimeToLive.TotalDays)
                                                 }
                                             }
-                                        }
                                     }
-                                }, token).ConfigureAwait(false), onRetry: x => { Logger.Warn($"Conflict when setting S3 lifecycle configuration, retrying after {x}ms."); }, cancellationToken: cancellationToken).ConfigureAwait(false);
-                    }
+                                }
+                            }, token).ConfigureAwait(false), onRetry: x => { Logger.Warn($"Conflict when setting S3 lifecycle configuration, retrying after {x}ms."); }, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
-            }
-            catch (Exception e)
-            {
-                Logger.Error("Exception from CreateQueueIfNecessary.", e);
-                throw;
             }
         }
 


### PR DESCRIPTION
The changes to `src/NServiceBus.Transport.SQS.Tests/Cleanup.cs` aren't strictly required (at least now). They are defensive, in case anyone adds a token to one of the calls.