### PR TITLE
TF 753 acceptance tests cleanup scheduled lambda

### DIFF
--- a/src/Tests.DeleteS3BucketsScheduledLambda/deployment/DeleteS3BucketsStack.cs
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/deployment/DeleteS3BucketsStack.cs
@@ -4,9 +4,9 @@ using Pulumi.Aws.Lambda;
 using Pulumi.Aws.CloudWatch;
 
 
-internal class DeleteS3BucketsStack : Stack
+class DeleteS3BucketsStack : Stack
 {
-    private const int LambdaMaxAllowedExecutionTimeInSeconds = 60;
+    const int LambdaMaxAllowedExecutionTimeInSeconds = 60;
     public DeleteS3BucketsStack()
     {
         var lambda = new Function("DeleteSQSTransportTestsExpiredAssets",
@@ -24,7 +24,7 @@ internal class DeleteS3BucketsStack : Stack
         CreateCloudWatchEventRule(lambda);
     }
 
-    private static Role CreateLambdaRole()
+    static Role CreateLambdaRole()
     {
         var lambdaRole = new Role("lambdaRole", new RoleArgs
         {
@@ -79,19 +79,19 @@ internal class DeleteS3BucketsStack : Stack
         return lambdaRole;
     }
 
-    private static void CreateCloudWatchEventRule(Function lambda)
+    static void CreateCloudWatchEventRule(Function lambda)
     {
-        var console = new EventRule("invoke-sqs-acceptance-tests-cleaner",
+        var scheduledRule = new EventRule("invoke-sqs-acceptance-tests-cleaner",
             new EventRuleArgs { ScheduleExpression = "rate(2 minutes)" });
 
-        new EventTarget("invokeLambda", new EventTargetArgs { Rule = console.Id, Arn = lambda.Arn, });
+        new EventTarget("invokeLambda", new EventTargetArgs { Rule = scheduledRule.Id, Arn = lambda.Arn, });
 
         new Permission("allowCloudwatch", new PermissionArgs
         {
             Action = "lambda:InvokeFunction",
             Function = lambda.Name,
             Principal = "events.amazonaws.com",
-            SourceArn = console.Arn,
+            SourceArn = scheduledRule.Arn,
         });
     }
 

--- a/src/Tests.DeleteS3BucketsScheduledLambda/deployment/DeleteS3BucketsStack.cs
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/deployment/DeleteS3BucketsStack.cs
@@ -1,0 +1,99 @@
+using Pulumi;
+using Pulumi.Aws.Iam;
+using Pulumi.Aws.Lambda;
+using Pulumi.Aws.CloudWatch;
+
+
+internal class DeleteS3BucketsStack : Stack
+{
+    private const int LambdaMaxAllowedExecutionTimeInSeconds = 60;
+    public DeleteS3BucketsStack()
+    {
+        var lambda = new Function("DeleteSQSTransportTestsExpiredAssets",
+            new FunctionArgs
+            {
+                Runtime = "dotnetcore3.1",
+                Code = new FileArchive("../lambda/bin/Debug/netcoreapp3.1/publish"),
+                Handler = "DeleteS3Buckets::DeleteS3Buckets.Function::FunctionHandler",
+                Role = CreateLambdaRole().Arn,
+                Timeout = LambdaMaxAllowedExecutionTimeInSeconds
+            });
+
+        Lambda = lambda.Arn;
+
+        CreateCloudWatchEventRule(lambda);
+    }
+
+    private static Role CreateLambdaRole()
+    {
+        var lambdaRole = new Role("lambdaRole", new RoleArgs
+        {
+            AssumeRolePolicy =
+                @"{
+                ""Version"": ""2012-10-17"",
+                ""Statement"": [
+                    {
+                        ""Action"": ""sts:AssumeRole"",
+                        ""Principal"": {
+                            ""Service"": ""lambda.amazonaws.com""
+                        },
+                        ""Effect"": ""Allow"",
+                        ""Sid"": """"
+                    }
+                ]
+            }"
+        });
+
+        new RolePolicy("lambdaLogPolicy", new RolePolicyArgs
+        {
+            Role = lambdaRole.Id,
+            Policy =
+                @"{
+                ""Version"": ""2012-10-17"",
+                ""Statement"": [{
+                    ""Effect"": ""Allow"",
+                    ""Action"": [
+                        ""logs:CreateLogGroup"",
+                        ""logs:CreateLogStream"",
+                        ""logs:PutLogEvents""
+                    ],
+                    ""Resource"": ""arn:aws:logs:*:*:*""
+                }]
+            }"
+        });
+
+        new RolePolicy("lambdaS3DeleteBucketAccess", new RolePolicyArgs
+        {
+            Role = lambdaRole.Id,
+            Policy =
+                @"{
+                ""Version"": ""2012-10-17"",
+                ""Statement"": [{
+                    ""Effect"": ""Allow"",
+                    ""Action"": ""s3:*"",
+                    ""Resource"": ""*""
+                }]
+            }"
+        });
+
+        return lambdaRole;
+    }
+
+    private static void CreateCloudWatchEventRule(Function lambda)
+    {
+        var console = new EventRule("invoke-sqs-acceptance-tests-cleaner",
+            new EventRuleArgs { ScheduleExpression = "rate(2 minutes)" });
+
+        new EventTarget("invokeLambda", new EventTargetArgs { Rule = console.Id, Arn = lambda.Arn, });
+
+        new Permission("allowCloudwatch", new PermissionArgs
+        {
+            Action = "lambda:InvokeFunction",
+            Function = lambda.Name,
+            Principal = "events.amazonaws.com",
+            SourceArn = console.Arn,
+        });
+    }
+
+    [Output] public Output<string> Lambda { get; set; }
+}

--- a/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Deployment.csproj
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Deployment.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>delete-s3-buckets-lambda-deployment</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pulumi.Aws" Version="4.*" />         
+  </ItemGroup>
+
+</Project>

--- a/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Program.cs
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Pulumi;
 
-internal class Program
+class Program
 {
     public static Task<int> Main()
     {

--- a/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Program.cs
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Program.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Pulumi;
+
+internal class Program
+{
+    public static Task<int> Main()
+    {
+        return Deployment.RunAsync<DeleteS3BucketsStack>();
+    }
+}

--- a/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Pulumi.prod.yaml
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Pulumi.prod.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: us-east-1

--- a/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Pulumi.yaml
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/deployment/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: sqs-transport-acceptance-testing
+runtime: dotnet
+description: Takes care of deploying AWS artifacts to aid with sqs transport acceptance
+  testing

--- a/src/Tests.DeleteS3BucketsScheduledLambda/lambda/DeleteS3Buckets.csproj
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/lambda/DeleteS3Buckets.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.7.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.1.27" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
+  </ItemGroup>
+</Project>

--- a/src/Tests.DeleteS3BucketsScheduledLambda/lambda/Function.cs
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/lambda/Function.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.Lambda.Core;
+using Amazon.Runtime.SharedInterfaces;
+using Newtonsoft.Json.Linq;
+using Amazon;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace DeleteS3Buckets
+{
+    public class Function
+    {
+        private const string NamePrefix = "cli-";
+
+        public async Task<string> FunctionHandler(JObject eventStr, ILambdaContext context)
+        {
+            try
+            {
+                await DeleteAllBucketsWithPrefix().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                LambdaLogger.Log(e.ToString());
+            }
+
+            return eventStr.ToString();
+        }
+
+        public static async Task DeleteAllBucketsWithPrefix()
+        {
+            var s3Client = new AmazonS3Client(RegionEndpoint.USEast1);
+
+            var listBucketsResponse = await s3Client.ListBucketsAsync(new ListBucketsRequest()).ConfigureAwait(false);
+
+            var deleteDateThreshold = DateTime.UtcNow.AddMinutes(-1);
+
+            var queryResult = listBucketsResponse.Buckets.Where(x =>
+                x.BucketName.StartsWith(NamePrefix, StringComparison.OrdinalIgnoreCase) &&
+                x.CreationDate < deleteDateThreshold).ToArray();
+
+            if (queryResult.Length == 0)
+            {
+                LambdaLogger.Log(
+                    $"There are zero {NamePrefix} buckets older than {deleteDateThreshold.Minute} minutes found to be deleted'");
+                return;
+            }
+
+            await Task.WhenAll(queryResult
+                .Select(x => x.BucketName).Select(async bucketName =>
+                {
+                    try
+                    {
+                        if (!await ((ICoreAmazonS3)s3Client).DoesS3BucketExistAsync(bucketName).ConfigureAwait(false))
+                        {
+                            return;
+                        }
+
+                        var response = await s3Client.GetBucketLocationAsync(bucketName);
+                        S3Region region;
+                        switch (response.Location)
+                        {
+                            case "":
+                                {
+                                    region = new S3Region("us-east-1");
+                                    break;
+                                }
+                            case "EU":
+                                {
+                                    region = S3Region.EUWest1;
+                                    break;
+                                }
+                            default:
+                                region = response.Location;
+                                break;
+                        }
+
+                        await s3Client.DeleteBucketAsync(new DeleteBucketRequest
+                        {
+                            BucketName = bucketName, BucketRegion = region
+                        });
+                        LambdaLogger.Log($"'{bucketName} bucket deleted'");
+                    }
+                    catch (AmazonS3Exception)
+                    {
+                        LambdaLogger.Log($"Unable to delete bucket '{bucketName}'");
+                    }
+                }));
+        }
+    }
+}

--- a/src/Tests.DeleteS3BucketsScheduledLambda/s3-buckets-auto-delete-lambda.sln
+++ b/src/Tests.DeleteS3BucketsScheduledLambda/s3-buckets-auto-delete-lambda.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.6.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deployment", "deployment\Deployment.csproj", "{506DAC78-310F-4413-97F5-D254D54A1F7B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteS3Buckets", "lambda\DeleteS3Buckets.csproj", "{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Debug|x64.Build.0 = Debug|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Debug|x86.Build.0 = Debug|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Release|x64.ActiveCfg = Release|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Release|x64.Build.0 = Release|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Release|x86.ActiveCfg = Release|Any CPU
+		{506DAC78-310F-4413-97F5-D254D54A1F7B}.Release|x86.Build.0 = Release|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Debug|x64.Build.0 = Debug|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Debug|x86.Build.0 = Debug|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Release|x64.ActiveCfg = Release|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Release|x64.Build.0 = Release|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Release|x86.ActiveCfg = Release|Any CPU
+		{ACA4C88C-5F94-48A0-A1A9-5843304FC6E8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
[TF work](https://github.com/Particular/KeepTheLightsOn/issues/753)

This PR Includes the lambda function code itself along with the code that takes care of the deployment of the lambda function with all its required artifacts like Roles, RolePolicies, and EventBridge Rule (CloudWatch Event) configuration.

Still pending:
- [x] Making code analysis checks pass.
- [ ] Convert hardcoded schedule frequency into a parameter in the pulumi stack YAML file.
- [ ] Update the documentation about the existence of the scheduled task and how to execute its deployment if the lambda function code ever gets updated. 
- [ ] Define the best folder name for the lambda scheduled function and its deployment "script."
- [ ] Nice to have: define if we want to add SNS notifications when the lambda function fails.
- [ ] Discuss naming conventions for the 7 cloud objects created by the deployment "script."
- [ ] Discuss possible code Reutilization: since the deployment "script" is written in C# (infrastructure as software), there is a chance to make the lambda function re-utilize the same code of https://github.com/Particular/NServiceBus.AmazonSQS/blob/master/src/NServiceBus.Transport.SQS.Tests/Cleanup.cs instead of duplicating it
- [ ] Discuss whether or not we want the Lambda function to delete not only S3 buckets but also delete any subscriptions, topics, and queues potentially being left behind too.