### PR TITLE
Include name of missing queues in exception details

### DIFF
--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
@@ -25,6 +25,5 @@
 
             StringAssert.Contains(nonExistingQueueName, exception.ToString());
         }
-
     }
 }

--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
@@ -15,7 +15,6 @@
                 },
                 (_, __) =>
                 {
-                    //onErrorCalled = true;
                     return Task.FromResult(ErrorHandleResult.Handled);
                 }, transactionMode);
 

--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System.Threading.Tasks;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+
+    public class Sending_to_non_existing_queues : NServiceBusTransportTest
+    {
+        [TestCase(TransportTransactionMode.None)]
+        public async Task Should_include_queue_name_in_exception_details(TransportTransactionMode transactionMode)
+        {
+            await StartPump((_, __) =>
+                {
+                    return Task.FromResult(0);
+                },
+                (_, __) =>
+                {
+                    //onErrorCalled = true;
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                }, transactionMode);
+
+            var nonExistingQueueName = "some-non-existing-queue";
+
+            var exception = Assert.CatchAsync(async () => await SendMessage(nonExistingQueueName));
+
+            StringAssert.Contains(nonExistingQueueName, exception.ToString());
+        }
+
+    }
+}

--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
@@ -7,6 +7,9 @@
     public class Sending_to_non_existing_queues : NServiceBusTransportTest
     {
         [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
         public async Task Should_include_queue_name_in_exception_details(TransportTransactionMode transactionMode)
         {
             await StartPump((_, __) =>

--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_to_non_existing_queues.cs
@@ -8,8 +8,6 @@
     {
         [TestCase(TransportTransactionMode.None)]
         [TestCase(TransportTransactionMode.ReceiveOnly)]
-        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
-        [TestCase(TransportTransactionMode.TransactionScope)]
         public async Task Should_include_queue_name_in_exception_details(TransportTransactionMode transactionMode)
         {
             await StartPump((_, __) =>

--- a/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
@@ -384,8 +384,16 @@
             else
             {
                 sqsPreparedMessage.Destination = transportOperation.Destination;
-                sqsPreparedMessage.QueueUrl = await queueCache.GetQueueUrl(sqsPreparedMessage.Destination, cancellationToken)
-                    .ConfigureAwait(false);
+
+                try
+                {
+                    sqsPreparedMessage.QueueUrl = await queueCache.GetQueueUrl(sqsPreparedMessage.Destination, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (QueueDoesNotExistException ex)
+                {
+                    throw new QueueDoesNotExistException($"Queue `{sqsPreparedMessage.Destination}` doesn't exist", ex);
+                }
 
                 if (delaySeconds > 0)
                 {


### PR DESCRIPTION
To make troubleshooting easier since the AWS SDK doesn't include the name of the queue that is missing.