### PR TITLE
Use a rate limiter and in-memory cache to fix rate exceeded exception when using pub/sub hybrid mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
       - name: Run Windows tests
         if: matrix.name == 'Windows'
         run: dotnet test src --configuration Release --no-build --logger "GitHubActions;report-warnings=false"
+        env:
+          NServiceBus_AmazonSQS_AT_CustomFixedNamePrefix: CiWinATT
       - name: Run Linux tests
         if: matrix.name == 'Linux'
         run: dotnet test src --configuration Release --no-build --framework netcoreapp3.1 --logger "GitHubActions;report-warnings=false"
+        env:
+          NServiceBus_AmazonSQS_AT_CustomFixedNamePrefix: CiNixATT

--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ The transport can be configured using the following environment variables:
 
 The names of queues used by the acceptance tests take the following form:
 
-    AT<datetime>-<pre-truncated-queue-name>
+    AT<sanitized-guid>-<pre-truncated-queue-name>
 
 Where
 
  * `AT` stands for "Acceptance Test"
- * `datetime` is a date and time as yyyyMMddHHmmss that uniquely identifies a single test run. For example, when 100 tests are executed in a single test run each queue will have the same datetime timestamp.
+ * `sanitized-guid` is a GUID converted to a base 64 string from which invalid characters are removed. For example, when 100 tests are executed in a single test run each queue will have the same `sanitized-guid`.
  * `pre-truncated-queue-name` is the name of the queue, "pre-truncated" (characters are removed from the beginning) so that the entire queue name is 80 characters or less. 
+
+_Note:_
+
+Some tests generate high load and require a fixed queue naming scheme to prevent policy propagation in the cluster to affect the test execution. The fixed resources prefix can be customized by using the `NServiceBus_AmazonSQS_AT_CustomFixedNamePrefix` environment variable. If not specified an exception will be thrown. For these tests the resources name schema is:
+
+    <name-prefix>-<optional-test-case-sequence>-<pre-truncated-queue-name>
+    
+Where `optional-test-case-sequence` is an optional integer value specified by tests using the NUnit test case feature to run the same test multiple times with different input values.
 
 This scheme accomplishes the following goals:
 

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/ConfigureEndpointSqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/ConfigureEndpointSqsTransport.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests
+namespace NServiceBus.AcceptanceTests
 {
     using System;
     using System.Threading.Tasks;
@@ -22,6 +22,9 @@
             transportConfig.ConfigureSqsTransport(SetupFixture.NamePrefix);
 
             ApplyMappingsToSupportMultipleInheritance(endpointName, transportConfig);
+
+            configuration.RegisterComponents(c => c.ConfigureComponent<TestIndependenceMutator>(DependencyLifecycle.SingleInstance));
+            configuration.Pipeline.Register("TestIndependenceBehavior", typeof(TestIndependenceSkipBehavior), "Skips messages not created during the current test.");
 
             settings.TestExecutionTimeout = TimeSpan.FromSeconds(120);
 

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/ConfigureEndpointSqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/ConfigureEndpointSqsTransport.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.AcceptanceTests
+﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
     using System.Threading.Tasks;
@@ -26,7 +26,12 @@ namespace NServiceBus.AcceptanceTests
             configuration.RegisterComponents(c => c.ConfigureComponent<TestIndependenceMutator>(DependencyLifecycle.SingleInstance));
             configuration.Pipeline.Register("TestIndependenceBehavior", typeof(TestIndependenceSkipBehavior), "Skips messages not created during the current test.");
 
-            settings.TestExecutionTimeout = TimeSpan.FromSeconds(120);
+            if (settings.TestExecutionTimeout == null)
+            {
+                //If it's not null it means it has been set to a custom
+                //value in the test. We don't want to overwrite that
+                settings.TestExecutionTimeout = TimeSpan.FromSeconds(120);
+            }
 
             return Task.FromResult(0);
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/TestCase.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/TestCase.cs
@@ -1,0 +1,28 @@
+namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
+{
+    using System;
+
+    public class TestCase
+    {
+        public TestCase(int sequence) => Sequence = sequence;
+
+        public int NumberOfEvents { get; internal set; }
+        public TimeSpan? TestExecutionTimeout { get; internal set; }
+        public int MessageVisibilityTimeout { get; internal set; } = DefaultMessageVisibilityTimeout;
+        public TimeSpan SubscriptionsCacheTTL { get; internal set; } = DefaultSubscriptionCacheTTL;
+        public TimeSpan NotFoundTopicsCacheTTL { get; internal set; } = DefaultTopicCacheTTL;
+        public int Sequence { get; }
+
+        public override string ToString() => $"#{Sequence}, " +
+            $"{nameof(NumberOfEvents)}: {NumberOfEvents}, " +
+            $"{nameof(MessageVisibilityTimeout)}: {(MessageVisibilityTimeout == DefaultMessageVisibilityTimeout ? "default" : MessageVisibilityTimeout.ToString())}, " +
+            $"{nameof(TestExecutionTimeout)}: {TestExecutionTimeout?.ToString() ?? "default"}, " +
+            $"{nameof(SubscriptionsCacheTTL)}: {(SubscriptionsCacheTTL == DefaultSubscriptionCacheTTL ? "default" : SubscriptionsCacheTTL.ToString())}, " +
+            $"{nameof(NotFoundTopicsCacheTTL)}: {(NotFoundTopicsCacheTTL == DefaultTopicCacheTTL ? "default" : NotFoundTopicsCacheTTL.ToString())}";
+
+        static TimeSpan DefaultSubscriptionCacheTTL = TimeSpan.FromSeconds(5);
+        static TimeSpan DefaultTopicCacheTTL = TimeSpan.FromSeconds(5);
+        static int DefaultMessageVisibilityTimeout = 30;
+
+    }
+}

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -1,0 +1,179 @@
+﻿namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Features;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
+
+    public class When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop : NServiceBusAcceptanceTest
+    {
+        static TestCase[] TestCases =
+        {
+            new TestCase(1){ NumberOfEvents = 1 },
+            new TestCase(2){ NumberOfEvents = 100 },
+            new TestCase(3){ NumberOfEvents = 300, SubscriptionsCacheTTL = TimeSpan.FromMinutes(1) },
+            new TestCase(4){ NumberOfEvents = 1000, TestExecutionTimeout = TimeSpan.FromMinutes(4), SubscriptionsCacheTTL = TimeSpan.FromMinutes(1), NotFoundTopicsCacheTTL = TimeSpan.FromMinutes(1) },
+        };
+
+        [Test, UseFixedNamePrefix, TestCaseSource(nameof(TestCases))]
+        public async Task Should_not_rate_exceed(TestCase testCase)
+        {
+            SetupFixture.AppendSequenceToNamePrefix(testCase.Sequence);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.CustomConfig(config =>
+                    {
+#pragma warning disable CS0618
+                        var migrationMode = config.ConfigureSqsTransport().EnableMessageDrivenPubSubCompatibilityMode();
+                        migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
+                        migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
+#pragma warning restore CS0618
+                    });
+
+                    b.When(c => c.SubscribedMessageDriven && c.SubscribedNative, (session, ctx) =>
+                    {
+                        var sw = Stopwatch.StartNew();
+                        var tasks = new List<Task>();
+                        for (int i = 0; i < testCase.NumberOfEvents; i++)
+                        {
+                            tasks.Add(session.Publish(new MyEvent()));
+                        }
+                        _ = Task.WhenAll(tasks).ContinueWith(t =>
+                        {
+                            sw.Stop();
+                            ctx.PublishTime = sw.Elapsed;
+                        });
+                        return Task.FromResult(0);
+                    });
+                })
+                .WithEndpoint<NativePubSubSubscriber>(b =>
+                {
+                    b.When((_, ctx) =>
+                    {
+                        ctx.SubscribedNative = true;
+                        return Task.FromResult(0);
+                    });
+                })
+                .WithEndpoint<MessageDrivenPubSubSubscriber>(b =>
+                {
+                    b.When((session, ctx) => session.Subscribe<MyEvent>());
+                })
+                .Done(c => c.NativePubSubSubscriberReceivedEventsCount == testCase.NumberOfEvents
+                    && c.MessageDrivenPubSubSubscriberReceivedEventsCount == testCase.NumberOfEvents)
+                .Run(testCase.TestExecutionTimeout);
+
+            Assert.AreEqual(testCase.NumberOfEvents, context.MessageDrivenPubSubSubscriberReceivedEventsCount);
+            Assert.AreEqual(testCase.NumberOfEvents, context.NativePubSubSubscriberReceivedEventsCount);
+        }
+
+        public class Context : ScenarioContext
+        {
+            int nativePubSubSubscriberReceivedEventsCount;
+            public int NativePubSubSubscriberReceivedEventsCount => nativePubSubSubscriberReceivedEventsCount;
+            public void IncrementNativePubSubSubscriberReceivedEventsCount()
+            {
+                Interlocked.Increment(ref nativePubSubSubscriberReceivedEventsCount);
+            }
+            int messageDrivenPubSubSubscriberReceivedEventsCount;
+            public int MessageDrivenPubSubSubscriberReceivedEventsCount => messageDrivenPubSubSubscriberReceivedEventsCount;
+            public void IncrementMessageDrivenPubSubSubscriberReceivedEventsCount()
+            {
+                Interlocked.Increment(ref messageDrivenPubSubSubscriberReceivedEventsCount);
+            }
+            public bool SubscribedMessageDriven { get; set; }
+            public bool SubscribedNative { get; set; }
+            public TimeSpan PublishTime { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var subscriptionStorage = new TestingInMemorySubscriptionStorage();
+                    c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+
+                    c.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(MessageDrivenPubSubSubscriber))))
+                        {
+                            context.SubscribedMessageDriven = true;
+                        }
+                    });
+                }).IncludeType<TestingInMemorySubscriptionPersistence>();
+            }
+        }
+
+        public class NativePubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public NativePubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c => { });
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementNativePubSubSubscriberReceivedEventsCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageDrivenPubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.GetSettings().Set("NServiceBus.AmazonSQS.DisableNativePubSub", true);
+                    c.GetSettings().GetOrCreate<Publishers>().AddOrReplacePublishers("LegacyConfig", new List<PublisherTableEntry>
+                    {
+                        new PublisherTableEntry(typeof(MyEvent), PublisherAddress.CreateFromEndpointName(Conventions.EndpointNamingConvention(typeof(Publisher))))
+                    });
+                },
+                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementMessageDrivenPubSubSubscriberReceivedEventsCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -1,0 +1,214 @@
+﻿namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
+{
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Features;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
+
+    public class When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message : NServiceBusAcceptanceTest
+    {
+        static TestCase[] TestCases =
+        {
+            new TestCase(1){ NumberOfEvents = 1 },
+            new TestCase(2){ NumberOfEvents = 100 },
+            new TestCase(3){ NumberOfEvents = 200 },
+            new TestCase(4){ NumberOfEvents = 300 },
+            new TestCase(5)
+            {
+                NumberOfEvents = 1000,
+                MessageVisibilityTimeout = 180,
+                TestExecutionTimeout = TimeSpan.FromMinutes(3),
+                SubscriptionsCacheTTL = TimeSpan.FromMinutes(1),
+                NotFoundTopicsCacheTTL = TimeSpan.FromMinutes(1),
+            },
+            new TestCase(6)
+            {
+                NumberOfEvents = 3000,
+                MessageVisibilityTimeout = 300,
+                TestExecutionTimeout = TimeSpan.FromMinutes(7),
+                SubscriptionsCacheTTL = TimeSpan.FromMinutes(2),
+                NotFoundTopicsCacheTTL = TimeSpan.FromMinutes(2),
+            },
+        };
+
+        [Test, UseFixedNamePrefix, TestCaseSource(nameof(TestCases))]
+        public async Task Should_not_rate_exceed(TestCase testCase)
+        {
+            SetupFixture.AppendSequenceToNamePrefix(testCase.Sequence);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.CustomConfig(config =>
+                    {
+#pragma warning disable CS0618
+                        var migrationMode = config.ConfigureSqsTransport().EnableMessageDrivenPubSubCompatibilityMode();
+                        migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
+                        migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
+                        migrationMode.MessageVisibilityTimeout(testCase.MessageVisibilityTimeout);
+#pragma warning restore CS0618
+                    });
+
+                    b.When(c => c.SubscribedMessageDriven && c.SubscribedNative, session =>
+                    {
+                        return session.SendLocal(new KickOff { NumberOfEvents = testCase.NumberOfEvents });
+                    });
+                })
+                .WithEndpoint<NativePubSubSubscriber>(b =>
+                {
+                    b.When((_, ctx) =>
+                    {
+                        ctx.SubscribedNative = true;
+                        return Task.FromResult(0);
+                    });
+                })
+                .WithEndpoint<MessageDrivenPubSubSubscriber>(b =>
+                {
+                    b.When((session, ctx) => session.Subscribe<MyEvent>());
+                })
+                .Done(c => c.NativePubSubSubscriberReceivedEventsCount == testCase.NumberOfEvents
+                && c.MessageDrivenPubSubSubscriberReceivedEventsCount == testCase.NumberOfEvents)
+                .Run(testCase.TestExecutionTimeout);
+
+            Assert.AreEqual(testCase.NumberOfEvents, context.MessageDrivenPubSubSubscriberReceivedEventsCount);
+            Assert.AreEqual(testCase.NumberOfEvents, context.NativePubSubSubscriberReceivedEventsCount);
+        }
+
+        public class Context : ScenarioContext
+        {
+            int nativePubSubSubscriberReceivedEventsCount;
+            public int NativePubSubSubscriberReceivedEventsCount => nativePubSubSubscriberReceivedEventsCount;
+            public void IncrementNativePubSubSubscriberReceivedEventsCount()
+            {
+                Interlocked.Increment(ref nativePubSubSubscriberReceivedEventsCount);
+            }
+
+            int messageDrivenPubSubSubscriberReceivedEventsCount;
+            public int MessageDrivenPubSubSubscriberReceivedEventsCount => messageDrivenPubSubSubscriberReceivedEventsCount;
+            public void IncrementMessageDrivenPubSubSubscriberReceivedEventsCount()
+            {
+                Interlocked.Increment(ref messageDrivenPubSubSubscriberReceivedEventsCount);
+            }
+            public bool SubscribedMessageDriven { get; set; }
+            public bool SubscribedNative { get; set; }
+            public TimeSpan PublishTime { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var subscriptionStorage = new TestingInMemorySubscriptionStorage();
+                    c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+
+                    c.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(MessageDrivenPubSubSubscriber))))
+                        {
+                            context.SubscribedMessageDriven = true;
+                        }
+                    });
+                }).IncludeType<TestingInMemorySubscriptionPersistence>();
+            }
+
+            public class KickOffMessageHandler : IHandleMessages<KickOff>
+            {
+                readonly Context testContext;
+
+                public KickOffMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public async Task Handle(KickOff message, IMessageHandlerContext context)
+                {
+                    var sw = Stopwatch.StartNew();
+                    var tasks = new List<Task>();
+                    for (int i = 0; i < message.NumberOfEvents; i++)
+                    {
+                        tasks.Add(context.Publish(new MyEvent()));
+                    }
+                    await Task.WhenAll(tasks);
+                    sw.Stop();
+                    testContext.PublishTime = sw.Elapsed;
+                }
+            }
+        }
+
+        public class NativePubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public NativePubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c => { });
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementNativePubSubSubscriberReceivedEventsCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageDrivenPubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.GetSettings().Set("NServiceBus.AmazonSQS.DisableNativePubSub", true);
+                    c.GetSettings().GetOrCreate<Publishers>().AddOrReplacePublishers("LegacyConfig", new List<PublisherTableEntry>
+                    {
+                        new PublisherTableEntry(typeof(MyEvent), PublisherAddress.CreateFromEndpointName(Conventions.EndpointNamingConvention(typeof(Publisher))))
+                    });
+                },
+                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementMessageDrivenPubSubSubscriberReceivedEventsCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class KickOff : ICommand
+        {
+            public int NumberOfEvents { get; set; }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -1,0 +1,242 @@
+﻿namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
+{
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Features;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
+
+    public class When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop : NServiceBusAcceptanceTest
+    {
+        static TestCase[] TestCases =
+        {
+            new TestCase(1)
+            {
+                NumberOfEvents = 1
+            },
+            new TestCase(2)
+            {
+                NumberOfEvents = 100,
+                SubscriptionsCacheTTL = TimeSpan.FromMinutes(1),
+                NotFoundTopicsCacheTTL = TimeSpan.FromMinutes(1),
+            },
+            new TestCase(3)
+            {
+                NumberOfEvents = 200,
+                SubscriptionsCacheTTL = TimeSpan.FromMinutes(3),
+                NotFoundTopicsCacheTTL = TimeSpan.FromMinutes(3),
+            }
+        };
+
+        [Test, UseFixedNamePrefix, TestCaseSource(nameof(TestCases))]
+        public async Task Should_not_rate_exceed(TestCase testCase)
+        {
+            SetupFixture.AppendSequenceToNamePrefix(testCase.Sequence);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.CustomConfig(config =>
+                    {
+#pragma warning disable CS0618
+                        var migrationMode = config.ConfigureSqsTransport().EnableMessageDrivenPubSubCompatibilityMode();
+                        migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
+                        migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
+#pragma warning restore CS0618
+                    });
+
+                    b.When(c => c.SubscribedMessageDrivenToMyEvent && c.SubscribedMessageDrivenToMySecondEvent && c.SubscribedNative, (session, ctx) =>
+                    {
+                        var sw = Stopwatch.StartNew();
+                        var tasks = new List<Task>();
+                        for (int i = 0; i < testCase.NumberOfEvents; i++)
+                        {
+                            tasks.Add(session.Publish(new MyEvent()));
+                            tasks.Add(session.Publish(new MySecondEvent()));
+                        }
+                        _ = Task.WhenAll(tasks).ContinueWith(t =>
+                        {
+                            sw.Stop();
+                            ctx.PublishTime = sw.Elapsed;
+                        });
+                        return Task.FromResult(0);
+                    });
+                })
+                .WithEndpoint<NativePubSubSubscriber>(b =>
+                {
+                    b.When((_, ctx) =>
+                    {
+                        ctx.SubscribedNative = true;
+                        return Task.FromResult(0);
+                    });
+                })
+                .WithEndpoint<MessageDrivenPubSubSubscriber>(b =>
+                {
+                    b.When(async (session, ctx) =>
+                    {
+                        await session.Subscribe<MyEvent>();
+                        await session.Subscribe<MySecondEvent>();
+                    });
+                })
+                .Done(c => c.NativePubSubSubscriberReceivedMyEventCount == testCase.NumberOfEvents
+                    && c.MessageDrivenPubSubSubscriberReceivedMyEventCount == testCase.NumberOfEvents
+                    && c.MessageDrivenPubSubSubscriberReceivedMySecondEventCount == testCase.NumberOfEvents)
+                .Run(testCase.TestExecutionTimeout);
+
+            Assert.AreEqual(testCase.NumberOfEvents, context.MessageDrivenPubSubSubscriberReceivedMyEventCount);
+            Assert.AreEqual(testCase.NumberOfEvents, context.NativePubSubSubscriberReceivedMyEventCount);
+            Assert.AreEqual(testCase.NumberOfEvents, context.MessageDrivenPubSubSubscriberReceivedMySecondEventCount);
+        }
+
+        public class Context : ScenarioContext
+        {
+            int nativePubSubSubscriberReceivedMyEventCount;
+            internal void IncrementNativePubSubSubscriberReceivedMyEventCount()
+            {
+                Interlocked.Increment(ref nativePubSubSubscriberReceivedMyEventCount);
+            }
+            public int NativePubSubSubscriberReceivedMyEventCount => nativePubSubSubscriberReceivedMyEventCount;
+
+            int messageDrivenPubSubSubscriberReceivedMyEventCount;
+            internal void IncrementMessageDrivenPubSubSubscriberReceivedMyEventCount()
+            {
+                Interlocked.Increment(ref messageDrivenPubSubSubscriberReceivedMyEventCount);
+            }
+            public int MessageDrivenPubSubSubscriberReceivedMyEventCount => messageDrivenPubSubSubscriberReceivedMyEventCount;
+
+            int messageDrivenPubSubSubscriberReceivedMySecondEventCount;
+            internal void IncrementMessageDrivenPubSubSubscriberReceivedMySecondEventCount()
+            {
+                Interlocked.Increment(ref messageDrivenPubSubSubscriberReceivedMySecondEventCount);
+            }
+            public int MessageDrivenPubSubSubscriberReceivedMySecondEventCount => messageDrivenPubSubSubscriberReceivedMySecondEventCount;
+            public bool SubscribedMessageDrivenToMyEvent { get; set; }
+            public bool SubscribedMessageDrivenToMySecondEvent { get; set; }
+            public bool SubscribedNative { get; set; }
+            public TimeSpan PublishTime { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var subscriptionStorage = new TestingInMemorySubscriptionStorage();
+                    c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+
+                    c.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (!s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(MessageDrivenPubSubSubscriber))))
+                        {
+                            return;
+                        }
+
+                        if (Type.GetType(s.MessageType) == typeof(MyEvent))
+                        {
+                            context.SubscribedMessageDrivenToMyEvent = true;
+                        }
+
+                        if (Type.GetType(s.MessageType) == typeof(MySecondEvent))
+                        {
+                            context.SubscribedMessageDrivenToMySecondEvent = true;
+                        }
+                    });
+                }).IncludeType<TestingInMemorySubscriptionPersistence>();
+            }
+        }
+
+        public class NativePubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public NativePubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c => { });
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementNativePubSubSubscriberReceivedMyEventCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageDrivenPubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.GetSettings().Set("NServiceBus.AmazonSQS.DisableNativePubSub", true);
+                    c.GetSettings().GetOrCreate<Publishers>().AddOrReplacePublishers("LegacyConfig", new List<PublisherTableEntry>
+                    {
+                        new PublisherTableEntry(typeof(MyEvent), PublisherAddress.CreateFromEndpointName(Conventions.EndpointNamingConvention(typeof(Publisher)))),
+                        new PublisherTableEntry(typeof(MySecondEvent), PublisherAddress.CreateFromEndpointName(Conventions.EndpointNamingConvention(typeof(Publisher))))
+                    });
+                },
+                metadata =>
+                {
+                    metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher));
+                    metadata.RegisterPublisherFor<MySecondEvent>(typeof(Publisher));
+                });
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementMessageDrivenPubSubSubscriberReceivedMyEventCount();
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class MySecondEventMessageHandler : IHandleMessages<MySecondEvent>
+            {
+                Context testContext;
+
+                public MySecondEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MySecondEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementMessageDrivenPubSubSubscriberReceivedMySecondEventCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+
+        public class MySecondEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -1,0 +1,276 @@
+﻿namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
+{
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NServiceBus.Features;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
+
+    public class When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message : NServiceBusAcceptanceTest
+    {
+        static TestCase[] TestCases =
+        {
+            new TestCase(1){ NumberOfEvents = 1 },
+            new TestCase(2){ NumberOfEvents = 100, MessageVisibilityTimeout = 60, },
+            new TestCase(3)
+            {
+                NumberOfEvents = 200,
+                MessageVisibilityTimeout = 120,
+                SubscriptionsCacheTTL = TimeSpan.FromMinutes(2),
+                NotFoundTopicsCacheTTL = TimeSpan.FromSeconds(120)
+            },
+            new TestCase(4)
+            {
+                NumberOfEvents = 300,
+                MessageVisibilityTimeout = 180,
+                TestExecutionTimeout = TimeSpan.FromMinutes(3),
+                SubscriptionsCacheTTL = TimeSpan.FromMinutes(2),
+                NotFoundTopicsCacheTTL = TimeSpan.FromSeconds(120)
+            },
+            new TestCase(5)
+            {
+                NumberOfEvents = 1000,
+                MessageVisibilityTimeout = 360,
+                SubscriptionsCacheTTL = TimeSpan.FromSeconds(120),
+                TestExecutionTimeout = TimeSpan.FromMinutes(8),
+                NotFoundTopicsCacheTTL = TimeSpan.FromSeconds(120)
+            },
+        };
+
+        [Test, UseFixedNamePrefix, TestCaseSource(nameof(TestCases))]
+        public async Task Should_not_rate_exceed(TestCase testCase)
+        {
+            SetupFixture.AppendSequenceToNamePrefix(testCase.Sequence);
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<MessageDrivenPubSubSubscriber>(b =>
+                {
+                    b.When(async (session, ctx) =>
+                    {
+                        TestContext.WriteLine("Sending subscriptions");
+                        await Task.WhenAll(
+                            session.Subscribe<MyEvent>(),
+                            session.Subscribe<MySecondEvent>()
+                        );
+                        TestContext.WriteLine("Subscriptions sent");
+                    });
+                })
+                .WithEndpoint<NativePubSubSubscriber>(b =>
+                {
+                    b.When((_, ctx) =>
+                    {
+                        ctx.SubscribedNative = true;
+                        return Task.FromResult(0);
+                    });
+                })
+                .WithEndpoint<Publisher>(b =>
+                {
+                    b.CustomConfig(config =>
+                    {
+#pragma warning disable CS0618
+                        var migrationMode = config.ConfigureSqsTransport().EnableMessageDrivenPubSubCompatibilityMode();
+                        migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
+                        migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
+                        migrationMode.MessageVisibilityTimeout(testCase.MessageVisibilityTimeout);
+#pragma warning restore CS0618
+                    });
+
+                    b.When(c => c.SubscribedMessageDrivenToMyEvent && c.SubscribedMessageDrivenToMySecondEvent && c.SubscribedNative, session =>
+                    {
+                        return session.SendLocal(new KickOff { NumberOfEvents = testCase.NumberOfEvents });
+                    });
+                })
+                .Done(c => c.NativePubSubSubscriberReceivedMyEventCount == testCase.NumberOfEvents
+                    && c.MessageDrivenPubSubSubscriberReceivedMyEventCount == testCase.NumberOfEvents
+                    && c.MessageDrivenPubSubSubscriberReceivedMySecondEventCount == testCase.NumberOfEvents)
+                .Run(testCase.TestExecutionTimeout);
+
+            Assert.AreEqual(testCase.NumberOfEvents, context.MessageDrivenPubSubSubscriberReceivedMyEventCount);
+            Assert.AreEqual(testCase.NumberOfEvents, context.NativePubSubSubscriberReceivedMyEventCount);
+            Assert.AreEqual(testCase.NumberOfEvents, context.MessageDrivenPubSubSubscriberReceivedMySecondEventCount);
+        }
+
+        public class Context : ScenarioContext
+        {
+            int nativePubSubSubscriberReceivedMyEventCount;
+            internal void IncrementNativePubSubSubscriberReceivedMyEventCount()
+            {
+                Interlocked.Increment(ref nativePubSubSubscriberReceivedMyEventCount);
+            }
+            public int NativePubSubSubscriberReceivedMyEventCount => nativePubSubSubscriberReceivedMyEventCount;
+
+            int messageDrivenPubSubSubscriberReceivedMyEventCount;
+            internal void IncrementMessageDrivenPubSubSubscriberReceivedMyEventCount()
+            {
+                Interlocked.Increment(ref messageDrivenPubSubSubscriberReceivedMyEventCount);
+            }
+            public int MessageDrivenPubSubSubscriberReceivedMyEventCount => messageDrivenPubSubSubscriberReceivedMyEventCount;
+
+            int messageDrivenPubSubSubscriberReceivedMySecondEventCount;
+            internal void IncrementMessageDrivenPubSubSubscriberReceivedMySecondEventCount()
+            {
+                Interlocked.Increment(ref messageDrivenPubSubSubscriberReceivedMySecondEventCount);
+            }
+            public int MessageDrivenPubSubSubscriberReceivedMySecondEventCount => messageDrivenPubSubSubscriberReceivedMySecondEventCount;
+
+            public bool SubscribedMessageDrivenToMyEvent { get; set; }
+            public bool SubscribedMessageDrivenToMySecondEvent { get; set; }
+            public bool SubscribedNative { get; set; }
+            public TimeSpan PublishTime { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    var subscriptionStorage = new TestingInMemorySubscriptionStorage();
+                    c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+
+                    c.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        TestContext.WriteLine($"Received subscription message {s.MessageType} from {s.SubscriberEndpoint}.");
+                        if (!s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(MessageDrivenPubSubSubscriber))))
+                        {
+                            return;
+                        }
+
+                        if (Type.GetType(s.MessageType) == typeof(MyEvent))
+                        {
+                            context.SubscribedMessageDrivenToMyEvent = true;
+                        }
+
+                        if (Type.GetType(s.MessageType) == typeof(MySecondEvent))
+                        {
+                            context.SubscribedMessageDrivenToMySecondEvent = true;
+                        }
+                        TestContext.WriteLine($"Subscription message processed.");
+                    });
+                }).IncludeType<TestingInMemorySubscriptionPersistence>();
+            }
+
+            public class KickOffMessageHandler : IHandleMessages<KickOff>
+            {
+                readonly Context testContext;
+
+                public KickOffMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public async Task Handle(KickOff message, IMessageHandlerContext context)
+                {
+                    var sw = Stopwatch.StartNew();
+                    var tasks = new List<Task>();
+                    for (int i = 0; i < message.NumberOfEvents; i++)
+                    {
+                        tasks.Add(context.Publish(new MyEvent()));
+                        tasks.Add(context.Publish(new MySecondEvent()));
+                    }
+                    await Task.WhenAll(tasks);
+                    sw.Stop();
+                    testContext.PublishTime = sw.Elapsed;
+                }
+            }
+        }
+
+        public class NativePubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public NativePubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c => { });
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementNativePubSubSubscriberReceivedMyEventCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageDrivenPubSubSubscriber : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPubSubSubscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.GetSettings().Set("NServiceBus.AmazonSQS.DisableNativePubSub", true);
+                    c.GetSettings().GetOrCreate<Publishers>().AddOrReplacePublishers("LegacyConfig", new List<PublisherTableEntry>
+                    {
+                        new PublisherTableEntry(typeof(MyEvent), PublisherAddress.CreateFromEndpointName(Conventions.EndpointNamingConvention(typeof(Publisher)))),
+                        new PublisherTableEntry(typeof(MySecondEvent), PublisherAddress.CreateFromEndpointName(Conventions.EndpointNamingConvention(typeof(Publisher))))
+                    });
+                },
+                metadata =>
+                {
+                    metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher));
+                    metadata.RegisterPublisherFor<MySecondEvent>(typeof(Publisher));
+                });
+            }
+
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public MyEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementMessageDrivenPubSubSubscriberReceivedMyEventCount();
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class MySecondEventMessageHandler : IHandleMessages<MySecondEvent>
+            {
+                Context testContext;
+
+                public MySecondEventMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MySecondEvent @event, IMessageHandlerContext context)
+                {
+                    testContext.IncrementMessageDrivenPubSubSubscriberReceivedMySecondEventCount();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class KickOff : ICommand
+        {
+            public int NumberOfEvents { get; set; }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+
+        public class MySecondEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
                     });
                 })
                 .Done(c => c.GotTheEvent)
-                .Run(TimeSpan.FromSeconds(30));
+                .Run(TimeSpan.FromSeconds(60));
 
             Assert.True(beforeMigration.GotTheEvent);
 
@@ -83,14 +83,14 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
                     });
                 })
                 .Done(c => c.GotTheEvent)
-                .Run(TimeSpan.FromSeconds(30));
+                .Run(TimeSpan.FromSeconds(60));
 
             Assert.True(publisherMigrated.GotTheEvent);
 
             //Subscriber migrated and in compatibility mode
             var subscriberMigratedRunSettings = new RunSettings
             {
-                TestExecutionTimeout = TimeSpan.FromSeconds(30)
+                TestExecutionTimeout = TimeSpan.FromSeconds(60)
             };
             var subscriberMigrated = await Scenario.Define<Context>()
                 .WithEndpoint<Publisher>(b =>
@@ -135,7 +135,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
                 })
                 .WithEndpoint<Subscriber>()
                 .Done(c => c.GotTheEvent)
-                .Run(TimeSpan.FromSeconds(30));
+                .Run(TimeSpan.FromSeconds(60));
 
             Assert.True(compatModeDisabled.GotTheEvent);
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
     {
         static string PublisherEndpoint => Conventions.EndpointNamingConvention(typeof(Publisher));
 
-        [Test]
+        [Test, UseFixedNamePrefix]
         public async Task Should_not_lose_any_events()
         {
             var subscriptionStorage = new TestingInMemorySubscriptionStorage();

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.NativePubSub
+namespace NServiceBus.AcceptanceTests.NativePubSub
 {
     using System;
     using System.Collections.Generic;
@@ -175,7 +175,7 @@
                     metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
-            public class MyHandler : IHandleMessages<MyEvent>
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
             {
                 public Context Context { get; set; }
 

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.NativePubSub
+namespace NServiceBus.AcceptanceTests.NativePubSub
 {
     using System;
     using System.Collections.Generic;
@@ -177,7 +177,7 @@
                     metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
-            public class MyHandler : IHandleMessages<MyEvent>
+            public class MyEventMessageHandler : IHandleMessages<MyEvent>
             {
                 public Context Context { get; set; }
 

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
     {
         static string PublisherEndpoint => Conventions.EndpointNamingConvention(typeof(Publisher));
 
-        [Test]
+        [Test, UseFixedNamePrefix]
         public async Task Should_not_lose_any_events()
         {
             var subscriptionStorage = new TestingInMemorySubscriptionStorage();

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
@@ -49,14 +49,14 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
                     });
                 })
                 .Done(c => c.GotTheEvent)
-                .Run(TimeSpan.FromSeconds(30));
+                .Run(TimeSpan.FromSeconds(60));
 
             Assert.True(beforeMigration.GotTheEvent);
 
             //Subscriber migrated and in compatibility mode.
             var subscriberMigratedRunSettings = new RunSettings
             {
-                TestExecutionTimeout = TimeSpan.FromSeconds(30)
+                TestExecutionTimeout = TimeSpan.FromSeconds(60)
             };
             var subscriberMigrated = await Scenario.Define<Context>()
                 .WithEndpoint<Publisher>(b =>
@@ -93,7 +93,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
             //Publisher migrated and in compatibility mode
             var publisherMigratedRunSettings = new RunSettings
             {
-                TestExecutionTimeout = TimeSpan.FromSeconds(30)
+                TestExecutionTimeout = TimeSpan.FromSeconds(60)
             };
             var publisherMigrated = await Scenario.Define<Context>()
                 .WithEndpoint<Publisher>(b =>
@@ -137,7 +137,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
                 })
                 .WithEndpoint<Subscriber>()
                 .Done(c => c.GotTheEvent)
-                .Run(TimeSpan.FromSeconds(30));
+                .Run(TimeSpan.FromSeconds(60));
 
             Assert.True(compatModeDisabled.GotTheEvent);
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/SetupFixture.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/SetupFixture.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.AcceptanceTests
+﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
     using System.Text.RegularExpressions;
@@ -56,6 +56,18 @@ namespace NServiceBus.AcceptanceTests
             }
         }
 
+        public static void AppendSequenceToNamePrefix(int sequence)
+        {
+            var idx = NamePrefix.LastIndexOf('-');
+            if (idx >= 0)
+            {
+                NamePrefix = NamePrefix.Substring(0, idx);
+            }
+            NamePrefix += $"-{sequence}";
+
+            TestContext.WriteLine($"Sequence #{sequence} appended name prefix: '{NamePrefix}'");
+        }
+
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
@@ -81,6 +93,13 @@ namespace NServiceBus.AcceptanceTests
             using (var s3Client = string.IsNullOrEmpty(accessKeyId) ? SqsTransportExtensions.CreateS3Client() :
                 new AmazonS3Client(accessKeyId, secretAccessKey))
             {
+                var idx = NamePrefix.LastIndexOf('-');
+                if (idx >= 0)
+                {
+                    //remove the sequence number before cleaning up
+                    NamePrefix = NamePrefix.Substring(0, idx);
+                }
+
                 await Cleanup.DeleteAllResourcesWithPrefix(sqsClient, snsClient, s3Client, NamePrefix).ConfigureAwait(false);
             }
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/TestIndependenceMutator.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/TestIndependenceMutator.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.MessageMutator;
+
+    class TestIndependenceMutator : IMutateOutgoingTransportMessages
+    {
+        readonly string testRunId;
+
+        public TestIndependenceMutator(ScenarioContext scenarioContext)
+        {
+            testRunId = scenarioContext.TestRunId.ToString();
+        }
+
+        public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+        {
+            context.OutgoingHeaders["$AcceptanceTesting.TestRunId"] = testRunId;
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/TestIndependenceSkipBehavior.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/TestIndependenceSkipBehavior.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    class TestIndependenceSkipBehavior : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
+    {
+        readonly string testRunId;
+
+        public TestIndependenceSkipBehavior(ScenarioContext scenarioContext)
+        {
+            testRunId = scenarioContext.TestRunId.ToString();
+        }
+
+        public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
+        {
+            if (context.Message.Headers.TryGetValue("$AcceptanceTesting.TestRunId", out var runId) && runId != testRunId)
+            {
+                TestContext.WriteLine($"Skipping message {context.Message.MessageId} from previous test run");
+                return Task.FromResult(0);
+            }
+
+            return next(context);
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/UseFixedNamePrefixAttribute.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/UseFixedNamePrefixAttribute.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
+    using System;
+
+    public class UseFixedNamePrefixAttribute : Attribute, ITestAction
+    {
+        public ActionTargets Targets => ActionTargets.Test;
+
+        public void AfterTest(ITest test) => SetupFixture.RestoreNamePrefixToRandomlyGenerated();
+        public void BeforeTest(ITest test) => SetupFixture.UseFixedNamePrefix();
+    }
+}

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
@@ -39,7 +39,7 @@ namespace NServiceBus
         [System.ObsoleteAttribute("The compatibility mode will be deprecated in the next major version of the transp" +
             "ort. Switch to native publish/subscribe mode using SNS instead. Will be treated " +
             "as an error from version 6.0.0. Will be removed in version 7.0.0.", false)]
-        public static NServiceBus.SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions) { }
+        public static NServiceBus.Transport.SQS.Configure.SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqsTransport> EnableV1CompatibilityMode(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions) { }
         public static void MapEvent<TSubscribedEvent>(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions, string customTopicName) { }
         public static void MapEvent(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions, System.Type eventType, string customTopicName) { }
@@ -54,5 +54,17 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.SqsTransport> TopicNameGenerator(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions, System.Func<System.Type, string, string> topicNameGenerator) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqsTransport> TopicNamePrefix(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions, string topicNamePrefix) { }
         public static NServiceBus.TransportExtensions<NServiceBus.SqsTransport> UnrestrictedDurationDelayedDelivery(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions) { }
+    }
+}
+namespace NServiceBus.Transport.SQS.Configure
+{
+    [System.ObsoleteAttribute("The compatibility mode will be deprecated in the next major version of the transp" +
+        "ort. Switch to native publish/subscribe mode using SNS instead. Will be treated " +
+        "as an error from version 6.0.0. Will be removed in version 7.0.0.", false)]
+    public class SqsSubscriptionMigrationModeSettings : NServiceBus.SubscriptionMigrationModeSettings
+    {
+        public NServiceBus.SubscriptionMigrationModeSettings MessageVisibilityTimeout(int timeoutInSeconds) { }
+        public NServiceBus.SubscriptionMigrationModeSettings SubscriptionsCacheTTL(System.TimeSpan ttl) { }
+        public NServiceBus.Transport.SQS.Configure.SqsSubscriptionMigrationModeSettings TopicCacheTTL(System.TimeSpan ttl) { }
     }
 }

--- a/src/NServiceBus.Transport.SQS.Tests/Cleanup.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/Cleanup.cs
@@ -39,6 +39,7 @@ namespace NServiceBus.Transport.SQS.Tests
         {
             await DeleteAllQueuesWithPrefix(sqsClient, "AT");
             await DeleteAllQueuesWithPrefix(sqsClient, "TT");
+            await DeleteAllQueuesWithPrefix(sqsClient, "cli");
         }
 
         [Test]
@@ -47,6 +48,7 @@ namespace NServiceBus.Transport.SQS.Tests
         {
             await DeleteAllSubscriptionsWithPrefix(snsClient, "AT");
             await DeleteAllSubscriptionsWithPrefix(snsClient, "TT");
+            await DeleteAllSubscriptionsWithPrefix(snsClient, "cli");
         }
 
         [Test]
@@ -55,6 +57,7 @@ namespace NServiceBus.Transport.SQS.Tests
         {
             await DeleteAllTopicsWithPrefix(snsClient, "AT");
             await DeleteAllTopicsWithPrefix(snsClient, "TT");
+            await DeleteAllTopicsWithPrefix(snsClient, "cli");
         }
 
         [Test]
@@ -70,6 +73,7 @@ namespace NServiceBus.Transport.SQS.Tests
         {
             await DeleteAllResourcesWithPrefix(sqsClient, snsClient, s3Client, "AT");
             await DeleteAllResourcesWithPrefix(sqsClient, snsClient, s3Client, "TT");
+            await DeleteAllResourcesWithPrefix(sqsClient, snsClient, s3Client, "cli");
         }
 
         public static Task DeleteAllResourcesWithPrefix(IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient, IAmazonS3 s3Client, string namePrefix)

--- a/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
@@ -725,7 +725,8 @@ namespace NServiceBus.Transport.SQS.Tests
 
         class TestableSubscriptionManager : SubscriptionManager
         {
-            public TestableSubscriptionManager(TransportConfiguration configuration, IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient, string queueName, QueueCache queueCache, MessageMetadataRegistry messageMetadataRegistry, TopicCache topicCache) : base(configuration, sqsClient, snsClient, queueName, queueCache, messageMetadataRegistry, topicCache)
+            public TestableSubscriptionManager(TransportConfiguration configuration, IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient, string queueName, QueueCache queueCache, MessageMetadataRegistry messageMetadataRegistry, TopicCache topicCache)
+                : base(configuration, sqsClient, snsClient, queueName, queueCache, messageMetadataRegistry, topicCache)
             {
             }
 

--- a/src/NServiceBus.Transport.SQS/Configure/SettingsKeys.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SettingsKeys.cs
@@ -31,5 +31,9 @@
         public const string V1CompatibilityMode = Prefix + nameof(V1CompatibilityMode);
         public const string DisableNativePubSub = Prefix + nameof(DisableNativePubSub);
         public const string DisableSubscribeBatchingOnStart = Prefix + nameof(DisableSubscribeBatchingOnStart);
+
+        public const string MessageVisibilityTimeout = Prefix + nameof(MessageVisibilityTimeout);
+        public const string SubscriptionsCacheTTL = Prefix + nameof(SubscriptionsCacheTTL);
+        public const string NotFoundTopicsCacheTTL = Prefix + nameof(NotFoundTopicsCacheTTL);
     }
 }

--- a/src/NServiceBus.Transport.SQS/Configure/SettingsKeys.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SettingsKeys.cs
@@ -35,5 +35,6 @@
         public const string MessageVisibilityTimeout = Prefix + nameof(MessageVisibilityTimeout);
         public const string SubscriptionsCacheTTL = Prefix + nameof(SubscriptionsCacheTTL);
         public const string NotFoundTopicsCacheTTL = Prefix + nameof(NotFoundTopicsCacheTTL);
+        public const string EnableMigrationModeSettingKey = "NServiceBus.Subscriptions.EnableMigrationMode";
     }
 }

--- a/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.Transport.SQS.Configure
+{
+    using System;
+    using Settings;
+
+    /// <summary>
+    /// Publish-subscribe migration mode configuration.
+    /// </summary>
+    [ObsoleteEx(
+        Message = @"The compatibility mode will be deprecated in the next major version of the transport. Switch to native publish/subscribe mode using SNS instead.",
+        TreatAsErrorFromVersion = "6.0",
+        RemoveInVersion = "7.0")]
+    public class SqsSubscriptionMigrationModeSettings : SubscriptionMigrationModeSettings
+    {
+        SettingsHolder settings;
+
+        internal SqsSubscriptionMigrationModeSettings(SettingsHolder settings) : base(settings)
+        {
+            this.settings = settings;
+        }
+
+        /// <summary>
+        /// Overrides the default value of 5 seconds for SNS topic cache.
+        /// </summary>
+        /// <param name="ttl">Topic cache TTL.</param>
+        public SqsSubscriptionMigrationModeSettings TopicCacheTTL(TimeSpan ttl)
+        {
+            Guard.AgainstNegativeAndZero(nameof(ttl), ttl);
+
+            settings.Set(SettingsKeys.NotFoundTopicsCacheTTL, ttl);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default value of 5 seconds for SNS topic subscribers cache.
+        /// </summary>
+        /// <param name="ttl">Subscription cache TTL.</param>
+        public SubscriptionMigrationModeSettings SubscriptionsCacheTTL(TimeSpan ttl)
+        {
+            Guard.AgainstNegativeAndZero(nameof(ttl), ttl);
+
+            settings.Set(SettingsKeys.SubscriptionsCacheTTL, ttl);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the default value of 30 seconds for SQS message visibility timeout.
+        /// </summary>
+        /// <param name="timeoutInSeconds">Message visibility timeout.</param>
+        public SubscriptionMigrationModeSettings MessageVisibilityTimeout(int timeoutInSeconds)
+        {
+            //HINT: See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+            if (timeoutInSeconds < 0 || timeoutInSeconds > TimeSpan.FromHours(12).TotalSeconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutInSeconds));
+            }
+
+            settings.Set(SettingsKeys.MessageVisibilityTimeout, timeoutInSeconds);
+
+            return this;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
@@ -111,6 +111,13 @@
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()
         {
+            if (configuration.UsingMessageDrivenPubSubCompatibilityMode && configuration.UsingDefaultMessageVisibilityTimeout)
+            {
+                Logger.Warn("When using message driven pub/sub compatibility mode, " +
+                    "it's suggested to set a custom message visibility timeout. " +
+                    "Refer to the message driven pub/sub compatibility mode documentation for more information.");
+            }
+
             return new TransportSendInfrastructure(
                 CreateMessageDispatcher,
                 () => Task.FromResult(StartupCheckResult.Success));

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
@@ -21,11 +21,11 @@
             Message = @"The compatibility mode will be deprecated in the next major version of the transport. Switch to native publish/subscribe mode using SNS instead.",
             TreatAsErrorFromVersion = "6.0",
             RemoveInVersion = "7.0")]
-        public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<SqsTransport> transportExtensions)
+        public static SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<SqsTransport> transportExtensions)
         {
             var settings = transportExtensions.GetSettings();
             settings.Set("NServiceBus.Subscriptions.EnableMigrationMode", true);
-            return new SubscriptionMigrationModeSettings(settings);
+            return new SqsSubscriptionMigrationModeSettings(settings);
         }
 
         /// <summary>

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
@@ -24,7 +24,7 @@
         public static SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<SqsTransport> transportExtensions)
         {
             var settings = transportExtensions.GetSettings();
-            settings.Set("NServiceBus.Subscriptions.EnableMigrationMode", true);
+            settings.Set(SettingsKeys.EnableMigrationModeSettingKey, true);
             return new SqsSubscriptionMigrationModeSettings(settings);
         }
 

--- a/src/NServiceBus.Transport.SQS/Guard.cs
+++ b/src/NServiceBus.Transport.SQS/Guard.cs
@@ -19,5 +19,13 @@
                 throw new ArgumentNullException(argumentName);
             }
         }
+
+        public static void AgainstNegativeAndZero(string argumentName, TimeSpan value)
+        {
+            if (value <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(argumentName);
+            }
+        }
     }
 }

--- a/src/NServiceBus.Transport.SQS/HybridPubSubChecker.cs
+++ b/src/NServiceBus.Transport.SQS/HybridPubSubChecker.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.Transport.SQS
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Amazon.SimpleNotificationService;
+    using NServiceBus.Logging;
+    using NServiceBus.Transport.SQS.Extensions;
+
+    class HybridPubSubChecker
+    {
+        class SubscritionCacheItem
+        {
+            public bool IsThereAnSnsSubscription { get; set; }
+            public DateTime Age { get; } = DateTime.Now;
+        }
+
+        public HybridPubSubChecker(TransportConfiguration configuration)
+        {
+            this.configuration = configuration;
+            cacheTTL = configuration.SubscriptionsCacheTTL;
+        }
+
+        bool TryGetFromCache(string cacheKey, out SubscritionCacheItem item)
+        {
+            item = null;
+            if (subscriptionsCache.TryGetValue(cacheKey, out var cacheItem))
+            {
+                Logger.Debug($"Subscription found in cache, key: '{cacheKey}'.");
+                if (cacheItem.Age.Add(cacheTTL) < DateTime.Now)
+                {
+                    Logger.Debug($"Removing subscription '{cacheKey}' from cache: TTL expired.");
+                    subscriptionsCache.TryRemove(cacheKey, out _);
+                }
+                else
+                {
+                    item = cacheItem;
+                }
+            }
+            else
+            {
+                Logger.Debug($"Subscription not found in cache, key: '{cacheKey}'.");
+            }
+
+            return item != null;
+        }
+
+        public async Task<bool> PublishUsingMessageDrivenPubSub(UnicastTransportOperation unicastTransportOperation, HashSet<string> messageIdsOfMulticastedEvents, TopicCache topicCache, QueueCache queueCache, IAmazonSimpleNotificationService snsClient)
+        {
+            // The following check is required by the message-driven pub/sub hybrid mode in Core
+            // to allow endpoints to migrate from message-driven pub/sub to native pub/sub
+            // If the message we're trying to dispatch is a unicast message with a `Publish` intent
+            // but the subscriber is also subscribed via SNS we don't want to dispatch the message twice
+            // the subscriber will receive it via SNS and not via a unicast send.
+            // We can improve the situation a bit by caching the information and thus reduce the amount of times we hit the SNS API.
+            // We need to think abut what happens in case the destination endpoint unsubscribes from the event.
+            // these conditions are carefully chosen to only execute the code if really necessary
+            if (unicastTransportOperation != null
+                && messageIdsOfMulticastedEvents.Contains(unicastTransportOperation.Message.MessageId)
+                && unicastTransportOperation.Message.GetMessageIntent() == MessageIntentEnum.Publish
+                && unicastTransportOperation.Message.Headers.ContainsKey(Headers.EnclosedMessageTypes))
+            {
+                var mostConcreteEnclosedMessageType = unicastTransportOperation.Message.GetEnclosedMessageTypes()[0];
+                var existingTopic = await topicCache.GetTopic(mostConcreteEnclosedMessageType).ConfigureAwait(false);
+                if (existingTopic == null)
+                {
+                    return true;
+                }
+
+                var cacheKey = existingTopic.TopicArn + unicastTransportOperation.Destination;
+                Logger.Debug($"Performing firt subscription cache lookup for '{cacheKey}'.");
+                if (!TryGetFromCache(cacheKey, out var cacheItem))
+                {
+                    cacheItem = await configuration.SnsListSubscriptionsByTopicRateLimiter.Execute(async () =>
+                    {
+                        Logger.Debug($"Performing second subscription cache lookup for '{cacheKey}'.");
+                        if (TryGetFromCache(cacheKey, out var secondAttemptItem))
+                        {
+                            return secondAttemptItem;
+                        }
+
+                        Logger.Debug($"Finding matching subscription for key '{cacheKey}' using SNS API.");
+                        var matchingSubscriptionArn = await snsClient.FindMatchingSubscription(queueCache, existingTopic, unicastTransportOperation.Destination)
+                            .ConfigureAwait(false);
+
+                        return new SubscritionCacheItem { IsThereAnSnsSubscription = matchingSubscriptionArn != null };
+                    }).ConfigureAwait(false);
+
+                    Logger.Debug($"Adding subscription to cache as '{(cacheItem.IsThereAnSnsSubscription ? "found" : "not found")}', key: '{cacheKey}'.");
+                    _ = subscriptionsCache.TryAdd(cacheKey, cacheItem);
+                }
+
+                if (cacheItem.IsThereAnSnsSubscription)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        TransportConfiguration configuration;
+        readonly TimeSpan cacheTTL;
+        readonly ConcurrentDictionary<string, SubscritionCacheItem> subscriptionsCache = new ConcurrentDictionary<string, SubscritionCacheItem>();
+        static ILog Logger = LogManager.GetLogger(typeof(HybridPubSubChecker));
+    }
+}

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -84,7 +84,8 @@ namespace NServiceBus.Transport.SQS
                 QueueUrl = inputQueueUrl,
                 WaitTimeSeconds = 20,
                 AttributeNames = new List<string> { "SentTimestamp" },
-                MessageAttributeNames = new List<string> { "*" }
+                MessageAttributeNames = new List<string> { "*" },
+                VisibilityTimeout = configuration.MessageVisibilityTimeout,
             };
 
             maxConcurrencySemaphore = new SemaphoreSlim(maxConcurrency);

--- a/src/NServiceBus.Transport.SQS/RateLimiter/AwaitableConstraint.cs
+++ b/src/NServiceBus.Transport.SQS/RateLimiter/AwaitableConstraint.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.Transport.SQS
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NServiceBus.Logging;
+
+    partial class RateLimiter
+    {
+        class AwaitableConstraint
+        {
+            public AwaitableConstraint(int maxAllowedRequests, TimeSpan timeConstraint, string apiName)
+            {
+                if (maxAllowedRequests <= 0)
+                {
+                    throw new ArgumentException($"{nameof(maxAllowedRequests)} must be greater than 0.", nameof(maxAllowedRequests));
+                }
+
+                if (timeConstraint.TotalMilliseconds <= 0)
+                {
+                    throw new ArgumentException($"{nameof(timeConstraint)} must be greater than 0.", nameof(timeConstraint));
+                }
+
+                this.maxAllowedRequests = maxAllowedRequests;
+                this.timeConstraint = timeConstraint;
+                this.apiName = apiName;
+                requestsTimeStamps = new SizeConstrainedStack<DateTime>(this.maxAllowedRequests);
+            }
+
+            public async Task<IDisposable> WaitIfNeeded()
+            {
+                await semaphore.WaitAsync().ConfigureAwait(false);
+
+                var requestsCount = 0;
+                var now = DateTime.Now;
+                var allocatedTimeLowerBound = now - timeConstraint;
+                var request = requestsTimeStamps.First;
+                LinkedListNode<DateTime> lastRequest = null;
+                while ((request != null) && (request.Value > allocatedTimeLowerBound))
+                {
+                    //counting how many requests have already
+                    //been performed within the allocated time
+                    lastRequest = request;
+                    request = request.Next;
+                    requestsCount++;
+                }
+
+                if (requestsCount < maxAllowedRequests)
+                {
+                    return new DisposableAction(OnActionDisposed);
+                }
+
+                Debug.Assert(request == null);
+                Debug.Assert(lastRequest != null);
+                var timeToWait = lastRequest.Value.Add(timeConstraint) - now;
+                try
+                {
+                    Logger.Info($"Requests threshold of {maxAllowedRequests} requests every {timeConstraint} reached for API '{apiName}'. Waiting {timeToWait}.");
+                    await Task.Delay(timeToWait).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    _ = semaphore.Release();
+                    throw;
+                }
+
+                return new DisposableAction(OnActionDisposed);
+            }
+
+            void OnActionDisposed()
+            {
+                //pushing as time stamp the request completion time
+                requestsTimeStamps.Push(DateTime.Now);
+                _ = semaphore.Release();
+            }
+
+            readonly SizeConstrainedStack<DateTime> requestsTimeStamps;
+
+            readonly int maxAllowedRequests;
+            TimeSpan timeConstraint;
+            readonly string apiName;
+            readonly SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+            static ILog Logger = LogManager.GetLogger(typeof(AwaitableConstraint));
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/RateLimiter/DisposableAction.cs
+++ b/src/NServiceBus.Transport.SQS/RateLimiter/DisposableAction.cs
@@ -1,0 +1,23 @@
+﻿namespace NServiceBus.Transport.SQS
+{
+    using System;
+
+    partial class RateLimiter
+    {
+        class DisposableAction : IDisposable
+        {
+            public DisposableAction(Action onDisposedCallback)
+            {
+                this.onDisposedCallback = onDisposedCallback;
+            }
+
+            public void Dispose()
+            {
+                onDisposedCallback?.Invoke();
+                onDisposedCallback = null;
+            }
+
+            Action onDisposedCallback;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/RateLimiter/RateLimiter.cs
+++ b/src/NServiceBus.Transport.SQS/RateLimiter/RateLimiter.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Transport.SQS
+{
+    using System;
+    using System.Threading.Tasks;
+
+    //implementation adapted from https://david-desmaisons.github.io/RateLimiter/
+    //we couldn't use the OSS package due to dependencies constrains: the above-linked package requires .NET 4.7.2
+    abstract partial class RateLimiter
+    {
+        protected RateLimiter(int maxAllowedRequests, TimeSpan timeConstraint, string limitedApiName) => awaitableConstraint = new AwaitableConstraint(maxAllowedRequests, timeConstraint, limitedApiName);
+
+        public async Task<T> Execute<T>(Func<Task<T>> taskToExecute)
+        {
+            using (await awaitableConstraint.WaitIfNeeded().ConfigureAwait(false))
+            {
+                return await taskToExecute().ConfigureAwait(false);
+            }
+        }
+
+        readonly AwaitableConstraint awaitableConstraint;
+    }
+}

--- a/src/NServiceBus.Transport.SQS/RateLimiter/SizeConstrainedStack.cs
+++ b/src/NServiceBus.Transport.SQS/RateLimiter/SizeConstrainedStack.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.Transport.SQS
+{
+    using System.Collections.Generic;
+
+    partial class RateLimiter
+    {
+        class SizeConstrainedStack<T> : LinkedList<T>
+        {
+            public SizeConstrainedStack(int maxSize)
+            {
+                this.maxSize = maxSize;
+            }
+
+            public void Push(T item)
+            {
+                AddFirst(item);
+
+                if (Count > maxSize)
+                {
+                    RemoveLast();
+                }
+            }
+
+            readonly int maxSize;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/RateLimiter/SnsListSubscriptionsByTopicRateLimiter.cs
+++ b/src/NServiceBus.Transport.SQS/RateLimiter/SnsListSubscriptionsByTopicRateLimiter.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.Transport.SQS
+{
+    using System;
+
+    class SnsListSubscriptionsByTopicRateLimiter : RateLimiter
+    {
+        public SnsListSubscriptionsByTopicRateLimiter()
+            : base(30, TimeSpan.FromSeconds(1), "ListSubscriptionsByTopic")
+        {
+
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/RateLimiter/SnsListTopicsRateLimiter.cs
+++ b/src/NServiceBus.Transport.SQS/RateLimiter/SnsListTopicsRateLimiter.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.Transport.SQS
+{
+    using System;
+
+    class SnsListTopicsRateLimiter : RateLimiter
+    {
+        public SnsListTopicsRateLimiter()
+            : base(30, TimeSpan.FromSeconds(1), "ListTopics")
+        {
+
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/SubscriptionManager.cs
+++ b/src/NServiceBus.Transport.SQS/SubscriptionManager.cs
@@ -87,7 +87,7 @@ namespace NServiceBus.Transport.SQS
             foreach (var mappedTopicName in mappedTopicsNames)
             {
                 //we skip the topic name generation assuming the topic name is already good
-                var mappedTypeMatchingSubscription = await snsClient.FindMatchingSubscription(queueCache, mappedTopicName, queueName)
+                var mappedTypeMatchingSubscription = await snsClient.FindMatchingSubscription(queueCache, mappedTopicName, queueName, configuration.SnsListTopicsRateLimiter, configuration.SnsListSubscriptionsByTopicRateLimiter)
                     .ConfigureAwait(false);
                 if (mappedTypeMatchingSubscription != null)
                 {
@@ -107,7 +107,7 @@ namespace NServiceBus.Transport.SQS
                     continue;
                 }
 
-                var mappedTypeMatchingSubscription = await snsClient.FindMatchingSubscription(queueCache, topicCache, mappedTypeMetadata, queueName)
+                var mappedTypeMatchingSubscription = await snsClient.FindMatchingSubscription(queueCache, topicCache, mappedTypeMetadata, queueName, configuration.SnsListSubscriptionsByTopicRateLimiter)
                     .ConfigureAwait(false);
                 if (mappedTypeMatchingSubscription != null)
                 {
@@ -117,7 +117,7 @@ namespace NServiceBus.Transport.SQS
                 }
             }
 
-            var matchingSubscriptionArn = await snsClient.FindMatchingSubscription(queueCache, topicCache, metadata, queueName)
+            var matchingSubscriptionArn = await snsClient.FindMatchingSubscription(queueCache, topicCache, metadata, queueName, configuration.SnsListSubscriptionsByTopicRateLimiter)
                 .ConfigureAwait(false);
             if (matchingSubscriptionArn != null)
             {

--- a/src/NServiceBus.Transport.SQS/TopicCache.cs
+++ b/src/NServiceBus.Transport.SQS/TopicCache.cs
@@ -4,11 +4,20 @@ namespace NServiceBus.Transport.SQS
     using System.Collections.Concurrent;
     using System.Threading.Tasks;
     using Amazon.SimpleNotificationService;
+    using Amazon.SimpleNotificationService.Model;
     using Configure;
+    using NServiceBus.Logging;
     using Unicast.Messages;
 
     class TopicCache
     {
+        class TopicCacheItem
+        {
+            public Topic Topic { get; set; }
+
+            public DateTime CreatedOn { get; } = DateTime.Now;
+        }
+
         public TopicCache(IAmazonSimpleNotificationService snsClient, MessageMetadataRegistry messageMetadataRegistry, TransportConfiguration configuration)
         {
             this.configuration = configuration;
@@ -24,16 +33,27 @@ namespace NServiceBus.Transport.SQS
 
         public Task<string> GetTopicArn(MessageMetadata metadata)
         {
+            return GetAndCacheTopicIfFound(metadata).ContinueWith(t => t.Result?.TopicArn);
+        }
+
+        public Task<Topic> GetTopic(MessageMetadata metadata)
+        {
             return GetAndCacheTopicIfFound(metadata);
         }
 
         public Task<string> GetTopicArn(Type eventType)
         {
             var metadata = messageMetadataRegistry.GetMessageMetadata(eventType);
-            return GetAndCacheTopicIfFound(metadata);
+            return GetAndCacheTopicIfFound(metadata).ContinueWith(t => t.Result?.TopicArn);
         }
 
         public Task<string> GetTopicArn(string messageTypeIdentifier)
+        {
+            var metadata = messageMetadataRegistry.GetMessageMetadata(messageTypeIdentifier);
+            return GetAndCacheTopicIfFound(metadata).ContinueWith(t => t.Result?.TopicArn);
+        }
+
+        public Task<Topic> GetTopic(string messageTypeIdentifier)
         {
             var metadata = messageMetadataRegistry.GetMessageMetadata(messageTypeIdentifier);
             return GetAndCacheTopicIfFound(metadata);
@@ -49,22 +69,76 @@ namespace NServiceBus.Transport.SQS
             return topicNameCache.GetOrAdd(metadata.MessageType, configuration.TopicNameGenerator(metadata));
         }
 
-        async Task<string> GetAndCacheTopicIfFound(MessageMetadata metadata)
+        bool TryGetTopicFromCache(MessageMetadata metadata, out Topic topic)
         {
-            if (topicCache.TryGetValue(metadata.MessageType, out var topic))
+            if (topicCache.TryGetValue(metadata.MessageType, out var topicCacheItem))
             {
-                return topic;
+                if (topicCacheItem.Topic == null && topicCacheItem.CreatedOn.Add(configuration.NotFoundTopicsCacheTTL) < DateTime.Now)
+                {
+                    Logger.Debug($"Removing topic '<null>' with key '{metadata.MessageType}' from cache: TTL expired.");
+                    _ = topicCache.TryRemove(metadata.MessageType, out _);
+                }
+                else
+                {
+                    Logger.Debug($"Returning topic for '{metadata.MessageType}' from cache. Topic '{topicCacheItem.Topic?.TopicArn ?? "<null>"}'.");
+                    topic = topicCacheItem.Topic;
+                    return true;
+                }
             }
 
-            var topicName = GetTopicName(metadata);
-            var foundTopic = await snsClient.FindTopicAsync(topicName).ConfigureAwait(false);
-            return foundTopic != null ? topicCache.GetOrAdd(metadata.MessageType, foundTopic.TopicArn) : null;
+            topic = null;
+            return false;
+        }
+
+        async Task<Topic> GetAndCacheTopicIfFound(MessageMetadata metadata)
+        {
+            Logger.Debug($"Performing firt Topic cache lookup for '{metadata.MessageType}'.");
+            if (TryGetTopicFromCache(metadata, out var cachedTopic))
+            {
+                return cachedTopic;
+            }
+
+            Logger.Debug($"Topic for '{metadata.MessageType}' not found in cache.");
+
+            var foundTopic = await configuration.SnsListTopicsRateLimiter.Execute(async () =>
+            {
+                /*
+                 * Rate limiter serializes requests, only 1 thread is allowed per
+                 * rate limiter. Before trying to reach out to SNS we do another
+                 * cache lookup
+                 */
+                Logger.Debug($"Performing second Topic cache lookup for '{metadata.MessageType}'.");
+                if (TryGetTopicFromCache(metadata, out var cachedValue))
+                {
+                    return cachedValue;
+                }
+
+                var topicName = GetTopicName(metadata);
+                Logger.Debug($"Finding topic '{topicName}' using 'ListTopics' SNS API.");
+
+                return await snsClient.FindTopicAsync(topicName).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+
+            //We cache also null/not found topics, they'll be wiped
+            //from the cache at lookup time based on the configured TTL
+            var added = topicCache.TryAdd(metadata.MessageType, new TopicCacheItem() { Topic = foundTopic });
+            if (added)
+            {
+                Logger.Debug($"Added topic '{foundTopic?.TopicArn ?? "<null>"}' to cache. Cache items count: {topicCache.Count}.");
+            }
+            else
+            {
+                Logger.Debug($"Topic already present in cache. Topic '{foundTopic?.TopicArn ?? "<null>"}'. Cache items count: {topicCache.Count}.");
+            }
+
+            return foundTopic;
         }
 
         IAmazonSimpleNotificationService snsClient;
         MessageMetadataRegistry messageMetadataRegistry;
         TransportConfiguration configuration;
-        ConcurrentDictionary<Type, string> topicCache = new ConcurrentDictionary<Type, string>();
+        ConcurrentDictionary<Type, TopicCacheItem> topicCache = new ConcurrentDictionary<Type, TopicCacheItem>();
         ConcurrentDictionary<Type, string> topicNameCache = new ConcurrentDictionary<Type, string>();
+        static ILog Logger = LogManager.GetLogger(typeof(TopicCache));
     }
 }

--- a/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
+++ b/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
@@ -342,6 +342,9 @@
             }
         }
 
+        public bool UsingDefaultMessageVisibilityTimeout => !settings.HasSetting(SettingsKeys.MessageVisibilityTimeout);
+        public bool UsingMessageDrivenPubSubCompatibilityMode => settings.HasSetting(SettingsKeys.MessageVisibilityTimeout) && settings.Get<bool>(SettingsKeys.EnableMigrationModeSettingKey);
+
         public TimeSpan SubscriptionsCacheTTL
         {
             get

--- a/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
+++ b/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.Transport.SQS
+﻿namespace NServiceBus.Transport.SQS
 {
     using System;
     using System.Collections.Generic;
@@ -367,6 +367,10 @@ namespace NServiceBus.Transport.SQS
                 return notFoundTopicsCacheTTL.Value;
             }
         }
+
+        public SnsListTopicsRateLimiter SnsListTopicsRateLimiter { get; } = new SnsListTopicsRateLimiter();
+
+        public SnsListSubscriptionsByTopicRateLimiter SnsListSubscriptionsByTopicRateLimiter { get; } = new SnsListSubscriptionsByTopicRateLimiter();
 
         public EventToTopicsMappings CustomEventToTopicsMappings => settings.GetOrDefault<EventToTopicsMappings>();
         public EventToEventsMappings CustomEventToEventsMappings => settings.GetOrDefault<EventToEventsMappings>();

--- a/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
+++ b/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport.SQS
+namespace NServiceBus.Transport.SQS
 {
     using System;
     using System.Collections.Generic;
@@ -329,6 +329,45 @@
             }
         }
 
+        public int MessageVisibilityTimeout
+        {
+            get
+            {
+                if (!messageVisibilityTimeout.HasValue)
+                {
+                    messageVisibilityTimeout = settings.GetOrDefault<int?>(SettingsKeys.MessageVisibilityTimeout) ?? 30;
+                }
+
+                return messageVisibilityTimeout.Value;
+            }
+        }
+
+        public TimeSpan SubscriptionsCacheTTL
+        {
+            get
+            {
+                if (!subscriptionsCacheTTL.HasValue)
+                {
+                    subscriptionsCacheTTL = settings.GetOrDefault<TimeSpan?>(SettingsKeys.SubscriptionsCacheTTL) ?? TimeSpan.FromSeconds(5);
+                }
+
+                return subscriptionsCacheTTL.Value;
+            }
+        }
+
+        public TimeSpan NotFoundTopicsCacheTTL
+        {
+            get
+            {
+                if (!notFoundTopicsCacheTTL.HasValue)
+                {
+                    notFoundTopicsCacheTTL = settings.GetOrDefault<TimeSpan?>(SettingsKeys.NotFoundTopicsCacheTTL) ?? TimeSpan.FromSeconds(5);
+                }
+
+                return notFoundTopicsCacheTTL.Value;
+            }
+        }
+
         public EventToTopicsMappings CustomEventToTopicsMappings => settings.GetOrDefault<EventToTopicsMappings>();
         public EventToEventsMappings CustomEventToEventsMappings => settings.GetOrDefault<EventToEventsMappings>();
 
@@ -370,6 +409,9 @@
         bool? preTruncateTopicNames;
         bool? useV1CompatiblePayload;
         int? queueDelayTime;
+        int? messageVisibilityTimeout;
+        TimeSpan? subscriptionsCacheTTL;
+        TimeSpan? notFoundTopicsCacheTTL;
         Func<IAmazonS3> s3ClientFactory;
         Func<IAmazonSQS> sqsClientFactory;
         Func<IAmazonSimpleNotificationService> snsClientFactory;


### PR DESCRIPTION
When using message-driven pub/sub compatibility mode, the transport might throw a `rate exceeded` due to AWS rate-limiting the usage of some APIs. Specifically `ListTopics` and `ListSubscriptionsByTopic`. This PR introduces a rate limiter to prevent AWS exceptions and an in-memory caching layer to minimize the rate limiter usage, which might impact performance.

---

## Problem description

When message-driven pub/sub compatibility mode is enabled, the transport needs to check if the message it's trying to dispatch is a unicast message with a `Publish` intent, and the subscriber is also subscribed via SNS. If this is the case, the transport doesn't dispatch the message twice; the subscriber will receive it via SNS and not via a unicast send. To check if, in this scenario, subscribers are subscribed via SNS, the transport uses the `FindSubscriptionsByTopic` API to list all the subscriptions to a topic and retrieve the destination queues.

`ListSubscriptionsByTopic` is [rate limited to 30 requests per second](https://docs.aws.amazon.com/general/latest/gr/sns.html), under high throughput, the limit is very quickly exceeded as an endpoint in the hybrid mode performs the check for every message published.

The problem is particularly evident when the environment is composed of mixed subscribers (both native and message-driven). A similar problem happens if the environment is composed mostly or only of message-driven subscribers, but message-driven pub/sub compatibility mode is enabled on publishers. This is the case when the migration to native pub/sub is about to start. Publishers, when publishing, still needs to check the SNS topology; however, in this second scenario, there'll be no topics (or very few topics), meaning that the transport will continuously try to look for non-existent topics. The API that gets rate limited is `ListTopics` ([rate limited to 30 requests per second](https://docs.aws.amazon.com/general/latest/gr/sns.html)).

## Implemented solution

This PR introduces an in-memory rate limiter that limits calls, respectively, to the `ListTopics` and `ListSubscriptionsByTopic` APIs to prevent rate exceeded exceptions. The rate limiter behaves as a bottleneck and causes some performance degradation. To avoid performance issues, the transport caches `ListTopics` and `ListSubscriptionsByTopic` results, by default, for 5 seconds (configuration options are available to tweak the values). It's essential to notice that the transport caches `null` results too; otherwise, there are scenarios in which the transport will continuously query the AWS API anyway. For example, if an API call to `ListTopics` returns no results, the not found result (`null`) is cached. The transport assumes that the topic doesn't exist for the next 5 seconds (by default). The same behavior applies to subscriptions lookup using the `ListSubscriptionsByTopic` API. If a subscription doesn't exist at the query time, the result is cached as `null` for the configured time to live.

When using one of the rate-limited APIs, the transport first checks the cache for any cached value. If nothing is available in the cache, it goes through the rate limiter to prevent any rate exceeded exception. However, before hitting the AWS API, it rechecks the cache. The second (inside the rate limiter) check is required to guarantee that when publishing events in a tight loop, every publish attempt hits the AWS API even if the previous one cached values.

---

Replaces https://github.com/Particular/NServiceBus.AmazonSQS/pull/933, fix https://github.com/Particular/NServiceBus.AmazonSQS/issues/866