### PR TITLE
Update AWS SDK dependencies to 3.7.*

### DIFF
--- a/src/CommandLine/Bucket.cs
+++ b/src/CommandLine/Bucket.cs
@@ -90,7 +90,7 @@
                         }
                     case "EU":
                         {
-                            region = S3Region.EUW1;
+                            region = S3Region.EUWest1;
                             break;
                         }
                     default:

--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.8" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />

--- a/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.8" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.8" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.6.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/src/NServiceBus.Transport.SQS.Tests/Cleanup.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/Cleanup.cs
@@ -112,7 +112,7 @@ namespace NServiceBus.Transport.SQS.Tests
                                 }
                             case "EU":
                                 {
-                                    region = S3Region.EUW1;
+                                    region = S3Region.EUWest1;
                                     break;
                                 }
                             default:

--- a/src/NServiceBus.Transport.SQS.Tests/MessageDispatcherTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MessageDispatcherTests.cs
@@ -512,9 +512,9 @@
                 {
                     return new SendMessageBatchResponse
                     {
-                        Failed = new List<BatchResultErrorEntry>
+                        Failed = new List<Amazon.SQS.Model.BatchResultErrorEntry>
                         {
-                            new BatchResultErrorEntry
+                            new Amazon.SQS.Model.BatchResultErrorEntry
                             {
                                 Id = firstMessageMatch.Id,
                                 Message = "You know why"
@@ -528,9 +528,9 @@
                 {
                     return new SendMessageBatchResponse
                     {
-                        Failed = new List<BatchResultErrorEntry>
+                        Failed = new List<Amazon.SQS.Model.BatchResultErrorEntry>
                         {
-                            new BatchResultErrorEntry
+                            new Amazon.SQS.Model.BatchResultErrorEntry
                             {
                                 Id = secondMessageMatch.Id,
                                 Message = "You know why"

--- a/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
@@ -1493,6 +1493,8 @@
         public PutBucketIntelligentTieringConfigurationResponse PutBucketIntelligentTieringConfiguration(PutBucketIntelligentTieringConfigurationRequest request) => throw new NotImplementedException();
 
         public Task<PutBucketIntelligentTieringConfigurationResponse> PutBucketIntelligentTieringConfigurationAsync(PutBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<WriteGetObjectResponseResponse> WriteGetObjectResponseAsync(WriteGetObjectResponseRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public WriteGetObjectResponseResponse WriteGetObjectResponse(WriteGetObjectResponseRequest request) => throw new NotImplementedException();
 
         public IS3PaginatorFactory Paginators { get; }
 

--- a/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
@@ -633,6 +633,21 @@ namespace NServiceBus.Transport.SQS.Tests
             throw new NotImplementedException();
         }
 
+        public Task<CreateSMSSandboxPhoneNumberResponse> CreateSMSSandboxPhoneNumberAsync(CreateSMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<DeleteSMSSandboxPhoneNumberResponse> DeleteSMSSandboxPhoneNumberAsync(DeleteSMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<GetSMSSandboxAccountStatusResponse> GetSMSSandboxAccountStatusAsync(GetSMSSandboxAccountStatusRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ListOriginationNumbersResponse> ListOriginationNumbersAsync(ListOriginationNumbersRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<ListSMSSandboxPhoneNumbersResponse> ListSMSSandboxPhoneNumbersAsync(ListSMSSandboxPhoneNumbersRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<PublishBatchResponse> PublishBatchAsync(PublishBatchRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<VerifySMSSandboxPhoneNumberResponse> VerifySMSSandboxPhoneNumberAsync(VerifySMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public CreateSMSSandboxPhoneNumberResponse CreateSMSSandboxPhoneNumber(CreateSMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
+        public DeleteSMSSandboxPhoneNumberResponse DeleteSMSSandboxPhoneNumber(DeleteSMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
+        public GetSMSSandboxAccountStatusResponse GetSMSSandboxAccountStatus(GetSMSSandboxAccountStatusRequest request) => throw new NotImplementedException();
+        public ListOriginationNumbersResponse ListOriginationNumbers(ListOriginationNumbersRequest request) => throw new NotImplementedException();
+        public ListSMSSandboxPhoneNumbersResponse ListSMSSandboxPhoneNumbers(ListSMSSandboxPhoneNumbersRequest request) => throw new NotImplementedException();
+        public PublishBatchResponse PublishBatch(PublishBatchRequest request) => throw new NotImplementedException();
+        public VerifySMSSandboxPhoneNumberResponse VerifySMSSandboxPhoneNumber(VerifySMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
+
         #endregion
     }
 }

--- a/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
@@ -1,3 +1,5 @@
+#pragma warning disable IDE0060 // Remove unused parameter
+
 namespace NServiceBus.Transport.SQS.Tests
 {
     using System;
@@ -651,3 +653,5 @@ namespace NServiceBus.Transport.SQS.Tests
         #endregion
     }
 }
+
+#pragma warning restore IDE0060 // Remove unused parameter

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.8" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NServiceBus" Version="7.4.1" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.5.7.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.5.1.30" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.5.1.8" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.6.0" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.7, 3.8)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7, 3.8)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.7, 3.8)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7.7.11, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.3.14, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.2.11, 3.8.0)" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="[7.2.4, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.5, 3.6)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.5, 3.6)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.5, 3.6)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.5, 3.8)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.5, 3.8)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.5, 3.8)" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="[7.2.4, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.5, 3.8)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.5, 3.8)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.5, 3.8)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7, 3.8)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7, 3.8)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7, 3.8)" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="[7.2.4, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />


### PR DESCRIPTION
Updated the upper bound of the AWS SDKs to match master. They are capped because the SDKs don't always follow SemVer.