### PR TITLE
Update aws dependencies for v5.4

### DIFF
--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.5, 3.6)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.5, 3.6)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.5, 3.6)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.5, 3.8)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.5, 3.8)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.5, 3.8)" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="[7.2.4, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />


### PR DESCRIPTION
Updated the upper bound of the AWS SDKs to match master. They are capped because the SDKs don't always follow SemVer.