### PR TITLE
Fix AWS dependency ranges

### DIFF
--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.5" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.57" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.31" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Particular.Packaging" Version="1.4.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.5" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.57" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.31" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.5" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.31" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.57" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-alpha.1902" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/src/NServiceBus.Transport.SQS.Tests/MessageDispatcherTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MessageDispatcherTests.cs
@@ -475,9 +475,9 @@
                 {
                     return new SendMessageBatchResponse
                     {
-                        Failed = new List<BatchResultErrorEntry>
+                        Failed = new List<Amazon.SQS.Model.BatchResultErrorEntry>
                         {
-                            new BatchResultErrorEntry
+                            new Amazon.SQS.Model.BatchResultErrorEntry
                             {
                                 Id = firstMessageMatch.Id,
                                 Message = "You know why"
@@ -491,9 +491,9 @@
                 {
                     return new SendMessageBatchResponse
                     {
-                        Failed = new List<BatchResultErrorEntry>
+                        Failed = new List<Amazon.SQS.Model.BatchResultErrorEntry>
                         {
-                            new BatchResultErrorEntry
+                            new Amazon.SQS.Model.BatchResultErrorEntry
                             {
                                 Id = secondMessageMatch.Id,
                                 Message = "You know why"

--- a/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
@@ -647,6 +647,8 @@ namespace NServiceBus.Transport.SQS.Tests
         public Task<ListSMSSandboxPhoneNumbersResponse> ListSMSSandboxPhoneNumbersAsync(ListSMSSandboxPhoneNumbersRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public VerifySMSSandboxPhoneNumberResponse VerifySMSSandboxPhoneNumber(VerifySMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
         public Task<VerifySMSSandboxPhoneNumberResponse> VerifySMSSandboxPhoneNumberAsync(VerifySMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public PublishBatchResponse PublishBatch(PublishBatchRequest request) => throw new NotImplementedException();
+        public Task<PublishBatchResponse> PublishBatchAsync(PublishBatchRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         #endregion
     }

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.5" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.57" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.31" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.5" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.57" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.31" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-alpha.1902" GeneratePathProperty="true" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.7.7.11, 3.8.0.0)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.3.14, 3.8.0.0)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.7.2.11, 3.8.0.0)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7.7.11, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.3.14, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.2.11, 3.8.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1902, 9.0.0)" />
     <PackageReference Include="Fody" Version="6.6.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.7, 3.8)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7, 3.8)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.7, 3.8)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7.7.11, 3.8.0.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.3.14, 3.8.0.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.2.11, 3.8.0.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1902, 9.0.0)" />
     <PackageReference Include="Fody" Version="6.6.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />


### PR DESCRIPTION
Minimum dependency number should be more specific for the transport project since nuget defaults to pulling the lowest version number that meets the range.

I also bumped the version numbers of the AWS SDK packages in the test projects to match those used in the main project