### PR TITLE
[5.6.1] Respect the message visibility timeout defined at the queue level

### DIFF
--- a/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
@@ -46,7 +46,7 @@
         }
 
         /// <summary>
-        /// Overrides the default value of 30 seconds for SQS message visibility timeout.
+        /// Overrides the default value specified at the queue level for message visibility timeout.
         /// </summary>
         /// <param name="timeoutInSeconds">Message visibility timeout.</param>
         public SubscriptionMigrationModeSettings MessageVisibilityTimeout(int timeoutInSeconds)

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -85,8 +85,13 @@ namespace NServiceBus.Transport.SQS
                 WaitTimeSeconds = 20,
                 AttributeNames = new List<string> { "SentTimestamp" },
                 MessageAttributeNames = new List<string> { "*" },
-                VisibilityTimeout = configuration.MessageVisibilityTimeout,
             };
+            //Set visibilitytimeout only when explicitly set by user configuration, else take the value in the queue
+            //users can define a custom visibility timeout only when using message driven pub/sub compatibility mode
+            if (configuration.MessageVisibilityTimeout.HasValue)
+            {
+                receiveMessagesRequest.VisibilityTimeout = configuration.MessageVisibilityTimeout.Value;
+            }
 
             maxConcurrencySemaphore = new SemaphoreSlim(maxConcurrency);
             pumpTasks = new List<Task>(numberOfPumps);

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="[7.2.4, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="1.4.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
+++ b/src/NServiceBus.Transport.SQS/TransportConfiguration.cs
@@ -329,18 +329,7 @@
             }
         }
 
-        public int MessageVisibilityTimeout
-        {
-            get
-            {
-                if (!messageVisibilityTimeout.HasValue)
-                {
-                    messageVisibilityTimeout = settings.GetOrDefault<int?>(SettingsKeys.MessageVisibilityTimeout) ?? 30;
-                }
-
-                return messageVisibilityTimeout.Value;
-            }
-        }
+        public int? MessageVisibilityTimeout => settings.GetOrDefault<int?>(SettingsKeys.MessageVisibilityTimeout);
 
         public bool UsingDefaultMessageVisibilityTimeout => !settings.HasSetting(SettingsKeys.MessageVisibilityTimeout);
         public bool UsingMessageDrivenPubSubCompatibilityMode => settings.HasSetting(SettingsKeys.MessageVisibilityTimeout) && settings.Get<bool>(SettingsKeys.EnableMigrationModeSettingKey);
@@ -416,7 +405,6 @@
         bool? preTruncateTopicNames;
         bool? useV1CompatiblePayload;
         int? queueDelayTime;
-        int? messageVisibilityTimeout;
         TimeSpan? subscriptionsCacheTTL;
         TimeSpan? notFoundTopicsCacheTTL;
         Func<IAmazonS3> s3ClientFactory;


### PR DESCRIPTION
In [NServiceBus.AmazonSQS 5.4](https://github.com/Particular/NServiceBus.AmazonSQS/releases/tag/5.4.0) a rate limiter and in-memory cache were introduced to fix a "rate exceeded" exception when using pub/sub compatibility mode—introducing the fix required to allow users to explicitly set the message visibility timeout when using the compatibility mode.

Unfortunately, due to the way it was implemented a message visibility timeout value is always set even if the compatibility mode is not enabled. When compatibility mode is not enabled the default value of 30 seconds is used for the visibility timeout and this causes the ReceiveMessageRequest to not use any visibility timeout specified on the queue when creating it.

This PR changes the transport behavior and stops setting a visibility timeout value if not explicitly set by the user code.

Related to #1158 