### PR TITLE
Bump AWS SDK dependencies

### DIFF
--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.25" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.32" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.29" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.54" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.4.7" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.104" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.25" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.32" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.29" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.54" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.4.7" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.104" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.25" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.29" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.32" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.54" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.104" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.4.7" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.0-rc.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />

--- a/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
@@ -1500,6 +1500,8 @@
         public PutBucketIntelligentTieringConfigurationResponse PutBucketIntelligentTieringConfiguration(PutBucketIntelligentTieringConfigurationRequest request) => throw new NotImplementedException();
 
         public Task<PutBucketIntelligentTieringConfigurationResponse> PutBucketIntelligentTieringConfigurationAsync(PutBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public GetObjectAttributesResponse GetObjectAttributes(GetObjectAttributesRequest request) => throw new NotImplementedException();
+        public Task<GetObjectAttributesResponse> GetObjectAttributesAsync(GetObjectAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public IS3PaginatorFactory Paginators { get; }
 

--- a/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
@@ -649,6 +649,10 @@ namespace NServiceBus.Transport.SQS.Tests
         public Task<VerifySMSSandboxPhoneNumberResponse> VerifySMSSandboxPhoneNumberAsync(VerifySMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public PublishBatchResponse PublishBatch(PublishBatchRequest request) => throw new NotImplementedException();
         public Task<PublishBatchResponse> PublishBatchAsync(PublishBatchRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public GetDataProtectionPolicyResponse GetDataProtectionPolicy(GetDataProtectionPolicyRequest request) => throw new NotImplementedException();
+        public Task<GetDataProtectionPolicyResponse> GetDataProtectionPolicyAsync(GetDataProtectionPolicyRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public PutDataProtectionPolicyResponse PutDataProtectionPolicy(PutDataProtectionPolicyRequest request) => throw new NotImplementedException();
+        public Task<PutDataProtectionPolicyResponse> PutDataProtectionPolicyAsync(PutDataProtectionPolicyRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         #endregion
     }

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.25" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.32" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.29" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.54" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.4.7" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.104" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.25" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.32" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.29" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.54" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.4.7" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.104" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.0-rc.3" GeneratePathProperty="true" />


### PR DESCRIPTION
Bump dependencies all at once in an attempt to overcome the chicken and egg problem caused by https://github.com/aws/aws-sdk-net/issues/1998