### PR TITLE
Remove the option to not deploy the topology

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -57,7 +57,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
                     {
                         b.CustomConfig(config =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                             var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
                             migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                             migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
@@ -84,7 +84,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When((_, ctx) =>
@@ -97,7 +97,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub.HybridModeRateLimit
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When((session, ctx) => session.Subscribe<MyEvent>());

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -71,7 +71,7 @@
                     {
                         b.CustomConfig(config =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                             var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
                             migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                             migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
@@ -87,7 +87,7 @@
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When((_, ctx) =>
@@ -100,7 +100,7 @@
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When((session, ctx) => session.Subscribe<MyEvent>());

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -75,7 +75,7 @@
                     {
                         b.CustomConfig(config =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                             var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
                             migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                             migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
@@ -103,7 +103,7 @@
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When((_, ctx) =>
@@ -116,7 +116,7 @@
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When(async (session, ctx) =>

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -72,7 +72,7 @@
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When(async (session, ctx) =>
@@ -89,7 +89,7 @@
                     {
                         b.CustomConfig((config, ctx) =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                         });
 
                         b.When((_, ctx) =>
@@ -102,7 +102,7 @@
                     {
                         b.CustomConfig(config =>
                         {
-                            config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
+                            // config.ConfigureSqsTransport().DeployInfrastructure = !testCase.PreDeployInfrastructure;
                             var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
                             migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                             migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -226,15 +226,12 @@
             var topicCache = new TopicCache(SnsClient, hostSettings.CoreSettings, eventToTopicsMappings, eventToEventsMappings, topicNameGenerator, topicNamePrefix);
             var infra = new SqsTransportInfrastructure(this, hostSettings, receivers, SqsClient, SnsClient, QueueCache, topicCache, S3, Policies, QueueDelayTime, topicNamePrefix, EnableV1CompatibilityMode);
 
-            if (DeployInfrastructure)
-            {
-                var queueCreator = new QueueCreator(SqsClient, QueueCache, S3, maxTimeToLive, QueueDelayTime);
+            var queueCreator = new QueueCreator(SqsClient, QueueCache, S3, maxTimeToLive, QueueDelayTime);
 
-                var createQueueTasks = sendingAddresses.Select(x => queueCreator.CreateQueueIfNecessary(x, false))
-                    .Concat(infra.Receivers.Values.Select(x => queueCreator.CreateQueueIfNecessary(x.ReceiveAddress, true))).ToArray();
+            var createQueueTasks = sendingAddresses.Select(x => queueCreator.CreateQueueIfNecessary(x, false))
+                .Concat(infra.Receivers.Values.Select(x => queueCreator.CreateQueueIfNecessary(x.ReceiveAddress, true))).ToArray();
 
-                await Task.WhenAll(createQueueTasks).ConfigureAwait(false);
-            }
+            await Task.WhenAll(createQueueTasks).ConfigureAwait(false);
 
             return infra;
         }
@@ -267,13 +264,6 @@
         QueueCache QueueCache =>
             queueCache ??= new QueueCache(SqsClient,
                 destination => queueNameGenerator(destination, QueueNamePrefix));
-
-        /// <summary>
-        /// Determines if the transport should try to create the
-        /// required resources (queues, topics, subscriptions, etc.).
-        /// The default value is <c>true</c>.
-        /// </summary>
-        internal bool DeployInfrastructure { get; set; } = true;
 
         /// <summary>
         /// Returns a list of all supported transaction modes of this transport.


### PR DESCRIPTION
It's YAGNI for now. Currently, #1643 only prevents the deployment of queues, but topics and subscriptions are always created no matter what. Given that CI is green, we can assume that the creation of those resources is idempotent. That said, we can also remove the option not to create queues.

The work in #1665 / #1625 will provide full installers support.