### PR TITLE
Update the max backoff interval to 60 seconds

### DIFF
--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -906,6 +906,6 @@
         const string EventType = "MyNamespace.MyMessage1";
         const string EventType2 = "MyNamespace.MyMessage2";
         const int VerificationBackoffInterval = 200;
-        const int MaximumBackoffInterval = 20000; // totals up to 77000
+        const int MaximumBackoffInterval = 60000;
     }
 }


### PR DESCRIPTION
Travis, Tomek, it seems to me that it makes sense to align the maximum backoff interval for command line tests to the overall value used by AWS for changes propagation.

For example, one of the command line flaky tests is the one that removes S3 buckets and included resources, the test waits for a certain amount of time before failing. That amount of time is 20 seconds, this PR changes that to 60

Thoughts?