### PR TITLE
Use Config.ClockOffset instead of CorrectClockSkew.GetClockCorrectionForEndpoint

### DIFF
--- a/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
@@ -6,7 +6,6 @@ namespace NServiceBus.Transport.SQS
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Amazon.Runtime;
     using Amazon.SQS;
     using Amazon.SQS.Model;
     using Extensions;
@@ -21,9 +20,6 @@ namespace NServiceBus.Transport.SQS
             this.queueCache = queueCache;
             this.queueDelayTimeSeconds = queueDelayTimeSeconds;
             this.sqsClient = sqsClient;
-#pragma warning disable CS0618
-            awsEndpointUrl = sqsClient.Config.DetermineServiceURL();
-#pragma warning restore CS0618
         }
 
         public async Task Initialize(CancellationToken cancellationToken = default)
@@ -149,7 +145,7 @@ namespace NServiceBus.Transport.SQS
                 return;
             }
 
-            var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(awsEndpointUrl);
+            var clockCorrection = sqsClient.Config.ClockOffset;
             var preparedMessages = PrepareMessages(receivedMessages, clockCorrection, cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -427,7 +423,6 @@ namespace NServiceBus.Transport.SQS
         readonly int queueDelayTimeSeconds;
         string delayedDeliveryQueueUrl;
         Task pumpTask;
-        string awsEndpointUrl;
         string inputQueueUrl;
 
         // using the same logger for now


### PR DESCRIPTION
Closes #1712 

Switched over to [`ClockOffset`](https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Core/Amazon.Runtime/ClientConfig.cs#L767). This still uses internally `DetermineServiceURL` but at least now this is no longer our problem since they somehow need to be fixing this and we are now using a non-obsoleted variant.

[`CorrectForClockSkew` seems to be set to `true` as a default.](https://github.com/aws/aws-sdk-net/blob/475822dec5e87954b7a47ac65995714ae1f1b115/sdk/src/Core/Amazon.Util/Internal/RootConfig.cs#L62).

What confuses me though is [this comment](https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Core/Amazon.Runtime/ClientConfig.cs#L759-L761)

> This field will be set if a service call resulted in an exception and the SDK has determined that there is a difference between local and server times.

[The property has not setter and the getter always determines the correction](https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Core/Amazon.Runtime/ClientConfig.cs#L777-L778)


