### PR TITLE
Bumping the minimum required SDK versions

### DIFF
--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.103.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.3" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.67" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />

--- a/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.103.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.2" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.3" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.67" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.103.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.2" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.67" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.3" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.3" GeneratePathProperty="true" />

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.103.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.2" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.3" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.67" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.103.1" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.2" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.3" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.67" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.7.101.10, 3.8.0)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.100.10, 3.8.0)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.7.100.9, 3.8.0)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7.103.2, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.101.3 , 3.8.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.100.67, 3.8.0)" />
     <PackageReference Include="BitFaster.Caching" Version="[2.1.1, 3.0.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="Fody" Version="6.6.4" PrivateAssets="All" />


### PR DESCRIPTION
Since we release a new minor let's bump the minimum required SDK versions to reasonable recent releases