### PR TITLE
[Backport to 5.6] Set a wildcard policy on flaky tests

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe.cs
@@ -12,7 +12,8 @@
         public async Task It_should_still_deliver()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Publisher>(b => b.When(c => c.Subscribed, (session, ctx) => Task.WhenAll(session.Publish(new MyEvent()), session.Publish(new MyOtherEvent()))))
+                .WithEndpoint<Publisher>(b => b.When(c => c.Subscribed, (session, _) =>
+                    Task.WhenAll(session.Publish(new MyEvent()), session.Publish(new MyOtherEvent()))))
                 .WithEndpoint<Subscriber>(b => b.When(async (session, ctx) =>
                 {
                     await Task.WhenAll(session.Subscribe<MyEvent>(), session.Subscribe<MyOtherEvent>());
@@ -34,21 +35,22 @@
 
         public class Publisher : EndpointConfigurationBuilder
         {
-            public Publisher()
-            {
-                EndpointSetup<DefaultPublisher>(c => { });
-            }
+            public Publisher() => EndpointSetup<DefaultPublisher>();
         }
 
         public class Subscriber : EndpointConfigurationBuilder
         {
-            public Subscriber()
-            {
+            public Subscriber() =>
                 EndpointSetup<DefaultServer>(c =>
                 {
+                    var transport = c.ConfigureSqsTransport();
+                    // Due to optimistic concurrency on queue metadata modifications it is required
+                    // to make sure the same policy outcome is achieved for all concurrent subscribes
+                    // otherwise policies might be partial which can lead to message loss
+                    transport.Policies.TopicNamespaceConditions.Add("NServiceBus.AcceptanceTests.NativePubSub");
+
                     c.DisableFeature<AutoSubscribe>();
                 });
-            }
 
             public class MyHandler : IHandleMessages<MyEvent>
             {

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe.cs
@@ -47,7 +47,7 @@
                     // Due to optimistic concurrency on queue metadata modifications it is required
                     // to make sure the same policy outcome is achieved for all concurrent subscribes
                     // otherwise policies might be partial which can lead to message loss
-                    transport.Policies.TopicNamespaceConditions.Add("NServiceBus.AcceptanceTests.NativePubSub");
+                    transport.Policies().AddNamespaceCondition("NServiceBus.AcceptanceTests.NativePubSub");
 
                     c.DisableFeature<AutoSubscribe>();
                 });

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe_with_scaled_subscriber.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe_with_scaled_subscriber.cs
@@ -12,7 +12,8 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
         public async Task It_should_still_deliver()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Publisher>(b => b.When(c => c.Instance1Subscribed && c.Instance2Subscribed, (session, ctx) => Task.WhenAll(session.Publish(new MyEvent()), session.Publish(new MyOtherEvent()))))
+                .WithEndpoint<Publisher>(b => b.When(c => c.Instance1Subscribed && c.Instance2Subscribed, (session, _) =>
+                    Task.WhenAll(session.Publish(new MyEvent()), session.Publish(new MyOtherEvent()))))
                 .WithEndpoint<Subscriber>(b => b.When(async (session, ctx) =>
                 {
                     await Task.WhenAll(session.Subscribe<MyEvent>(), session.Subscribe<MyOtherEvent>());
@@ -40,18 +41,22 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
 
         public class Publisher : EndpointConfigurationBuilder
         {
-            public Publisher()
-            {
-                EndpointSetup<DefaultPublisher>(c => { });
-            }
+            public Publisher() => EndpointSetup<DefaultPublisher>();
         }
 
         public class Subscriber : EndpointConfigurationBuilder
         {
-            public Subscriber()
-            {
-                EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); });
-            }
+            public Subscriber() =>
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var transport = c.ConfigureSqsTransport();
+                    // Due to optimistic concurrency on queue metadata modifications it is required
+                    // to make sure the same policy outcome is achieved for all concurrent subscribes
+                    // otherwise policies might be partial which can lead to message loss
+                    transport.Policies.TopicNamespaceConditions.Add("NServiceBus.AcceptanceTests.NativePubSub");
+
+                    c.DisableFeature<AutoSubscribe>();
+                });
 
             public class MyHandler : IHandleMessages<MyEvent>
             {

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe_with_scaled_subscriber.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_concurrent_subscribe_with_scaled_subscriber.cs
@@ -53,7 +53,7 @@ namespace NServiceBus.AcceptanceTests.NativePubSub
                     // Due to optimistic concurrency on queue metadata modifications it is required
                     // to make sure the same policy outcome is achieved for all concurrent subscribes
                     // otherwise policies might be partial which can lead to message loss
-                    transport.Policies.TopicNamespaceConditions.Add("NServiceBus.AcceptanceTests.NativePubSub");
+                    transport.Policies().AddNamespaceCondition("NServiceBus.AcceptanceTests.NativePubSub");
 
                     c.DisableFeature<AutoSubscribe>();
                 });


### PR DESCRIPTION
Backporting of https://github.com/Particular/NServiceBus.AmazonSQS/pull/1912