### PR TITLE
Add header for message body encoding type

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/When_receiving_a_native_message_without_wrapper.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/When_receiving_a_native_message_without_wrapper.cs
@@ -14,6 +14,9 @@
     public class When_receiving_a_native_message_without_wrapper : NServiceBusAcceptanceTest
     {
         static readonly string MessageToSend = new XDocument(new XElement("NServiceBus.AcceptanceTests.NativeIntegration.NativeMessage", new XElement("ThisIsTheMessage", "Hello!"))).ToString();
+        //NOTE the unicode gets converted to utf-16 by .net automatically
+        //static readonly string MessageToSendUnicode = new XDocument(new XElement("NServiceBus.AcceptanceTests.NativeIntegration.NativeMessage", new XElement("ThisIsTheMessage", @"This Unicode string contains two characters with codes outside the traditional ASCII code range, Pi (\u03a0) and Sigma (\u03a3)."))).ToString();
+        //static readonly string MessageToSendUnicode = new XDocument(new XElement("NServiceBus.AcceptanceTests.NativeIntegration.NativeMessage", new XElement("ThisIsTheMessage", "\u00abX\u00bb"))).ToString();
 
         [Test]
         public async Task Should_be_processed_when_nsbheaders_present_with_messageid()
@@ -38,6 +41,30 @@
 
             Assert.AreEqual("Hello!", context.MessageReceived);
         }
+
+        //[Test]
+        //public async Task Should_be_processed_when_nsbheaders_present_with_encoding_unicode_specified()
+        //{
+        //    var context = await Scenario.Define<Context>()
+        //        .WithEndpoint<Receiver>(c => c.When(async _ =>
+        //        {
+        //            await NativeEndpoint.SendTo<Receiver>(
+        //                new Dictionary<string, MessageAttributeValue>
+        //                {
+        //                    {
+        //                        "NServiceBus.AmazonSQS.Headers",
+        //                        new MessageAttributeValue
+        //                        {
+        //                            DataType = "String", StringValue = GetHeaders(messageId: Guid.NewGuid().ToString(), encoding: "unicode")
+        //                        }
+        //                    }
+        //                }, MessageToSendUnicode, false);
+        //        }))
+        //        .Done(c => c.MessageReceived != null)
+        //        .Run();
+
+        //    Assert.AreEqual("Hello", context.MessageReceived);
+        //}
 
         [Test]
         public async Task Should_be_processed_when_nsbheaders_present_without_messageid()
@@ -89,7 +116,7 @@
             Assert.AreEqual("Hello!", context.MessageReceived);
         }
 
-        string GetHeaders(string s3Key = null, string messageId = null)
+        string GetHeaders(string s3Key = null, string messageId = null, string encoding = null)
         {
             var nsbHeaders = new Dictionary<string, string>();
 
@@ -101,6 +128,11 @@
             if (!string.IsNullOrEmpty(messageId))
             {
                 nsbHeaders.Add("NServiceBus.MessageId", messageId);
+            }
+
+            if (!string.IsNullOrEmpty(encoding))
+            {
+                nsbHeaders.Add("NServiceBus.AmazonSQS.Encoding", encoding);
             }
 
             return JsonSerializer.Serialize(nsbHeaders);

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -284,6 +284,10 @@ namespace NServiceBus.Transport.SQS
                             transportMessage.Headers[TransportHeaders.S3BodyKey] = s3BodyKey.StringValue;
                             transportMessage.S3BodyKey = s3BodyKey.StringValue;
                         }
+                        if (receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.Encoding, out var messageEncoding))
+                        {
+                            transportMessage.Headers[TransportHeaders.Encoding] = messageEncoding.StringValue;
+                        }
                     }
                     else
                     {

--- a/src/NServiceBus.Transport.SQS/TransportHeaders.cs
+++ b/src/NServiceBus.Transport.SQS/TransportHeaders.cs
@@ -6,6 +6,7 @@
         public const string TimeToBeReceived = Prefix + nameof(TimeToBeReceived);
         public const string DelaySeconds = Prefix + nameof(DelaySeconds);
         public const string Headers = Prefix + nameof(Headers);
+        public const string Encoding = Prefix + nameof(Encoding);
         public const string S3BodyKey = "S3BodyKey";
         public const string MessageTypeFullName = "MessageTypeFullName";
     }


### PR DESCRIPTION
This needs a test but we seem to be unable to send a unicode string from .Net - it converts unicode characters to utf-16 on the fly. Unless there's some low level way of doing this that we don't know about?