### PR TITLE
[Backport 1909 to 5.7] Use Config.ClockOffset instead of CorrectClockSkew.GetClockCorrectionForEndpoint

### DIFF
--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.16" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.16" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.80" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />

--- a/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.16" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.16" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.80" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.16" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.16" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.80" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="7.6.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
@@ -832,6 +832,10 @@
             throw new NotImplementedException();
         }
 
+        public GetObjectAttributesResponse GetObjectAttributes(GetObjectAttributesRequest request) => throw new NotImplementedException();
+
+        public Task<GetObjectAttributesResponse> GetObjectAttributesAsync(GetObjectAttributesRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+
         public GetObjectLegalHoldResponse GetObjectLegalHold(GetObjectLegalHoldRequest request)
         {
             throw new NotImplementedException();

--- a/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
@@ -275,6 +275,10 @@ namespace NServiceBus.Transport.SQS.Tests
             throw new NotImplementedException();
         }
 
+        public GetDataProtectionPolicyResponse GetDataProtectionPolicy(GetDataProtectionPolicyRequest request) => throw new NotImplementedException();
+
+        public Task<GetDataProtectionPolicyResponse> GetDataProtectionPolicyAsync(GetDataProtectionPolicyRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+
         public GetEndpointAttributesResponse GetEndpointAttributes(GetEndpointAttributesRequest request)
         {
             throw new NotImplementedException();
@@ -510,6 +514,8 @@ namespace NServiceBus.Transport.SQS.Tests
             throw new NotImplementedException();
         }
 
+        public Task<PutDataProtectionPolicyResponse> PutDataProtectionPolicyAsync(PutDataProtectionPolicyRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+
         public RemovePermissionResponse RemovePermission(string topicArn, string label)
         {
             throw new NotImplementedException();
@@ -641,6 +647,8 @@ namespace NServiceBus.Transport.SQS.Tests
         public Task<ListOriginationNumbersResponse> ListOriginationNumbersAsync(ListOriginationNumbersRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<ListSMSSandboxPhoneNumbersResponse> ListSMSSandboxPhoneNumbersAsync(ListSMSSandboxPhoneNumbersRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public Task<PublishBatchResponse> PublishBatchAsync(PublishBatchRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public PutDataProtectionPolicyResponse PutDataProtectionPolicy(PutDataProtectionPolicyRequest request) => throw new NotImplementedException();
+
         public Task<VerifySMSSandboxPhoneNumberResponse> VerifySMSSandboxPhoneNumberAsync(VerifySMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public CreateSMSSandboxPhoneNumberResponse CreateSMSSandboxPhoneNumber(CreateSMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
         public DeleteSMSSandboxPhoneNumberResponse DeleteSMSSandboxPhoneNumber(DeleteSMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.16" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.16" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.80" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NServiceBus" Version="7.4.1" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.7.11" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.14" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.11" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.103.16" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.16" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.80" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="7.6.0" />

--- a/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
@@ -6,7 +6,6 @@ namespace NServiceBus.Transport.SQS
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Amazon.Runtime;
     using Amazon.SQS;
     using Amazon.SQS.Model;
     using Extensions;
@@ -19,7 +18,6 @@ namespace NServiceBus.Transport.SQS
             this.queueCache = queueCache;
             this.sqsClient = sqsClient;
             this.configuration = configuration;
-            awsEndpointUrl = sqsClient.Config.DetermineServiceURL();
         }
 
         public async Task Initialize(string inputQueue, string inputQueueUrl)
@@ -118,7 +116,7 @@ namespace NServiceBus.Transport.SQS
                 return;
             }
 
-            var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(awsEndpointUrl);
+            var clockCorrection = sqsClient.Config.ClockOffset;
             var preparedMessages = PrepareMessages(receivedMessages, clockCorrection, token);
 
             token.ThrowIfCancellationRequested();
@@ -400,7 +398,6 @@ namespace NServiceBus.Transport.SQS
         readonly QueueCache queueCache;
         string delayedDeliveryQueueUrl;
         Task pumpTask;
-        string awsEndpointUrl;
         string inputQueueUrl;
 
         // using the same logger for now

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.7.7.11, 3.8.0)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.3.14, 3.8.0)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.7.2.11, 3.8.0)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7.103.2, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.101.3 , 3.8.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.100.67, 3.8.0)" />
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="[7.2.4, 8.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />


### PR DESCRIPTION
Brings #1909 plus SDK bumps to `release-5.7`