### PR TITLE
Auto approve AWS dependencies and separate them to reduce the likelihood of merge conflicts

### DIFF
--- a/.github/workflows/approve-dependencies.yml
+++ b/.github/workflows/approve-dependencies.yml
@@ -1,0 +1,28 @@
+name: Auto-approve AWSSDK dependency updates
+on:
+  pull_request_target:
+    types: [ opened ]
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Prevent run from failing on non-Dependabot PRs
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.6
+      - name: Approve PR
+        if: ${{contains(steps.metadata.outputs.dependency-names, 'AWSSDK.SQS') || contains(steps.metadata.outputs.dependency-names, 'AWSSDK.SimpleNotificationService') || contains(steps.metadata.outputs.dependency-names, 'AWSSDK.S3}}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge
+        if: ${{contains(steps.metadata.outputs.dependency-names, 'AWSSDK.SQS') || contains(steps.metadata.outputs.dependency-names, 'AWSSDK.SimpleNotificationService') || contains(steps.metadata.outputs.dependency-names, 'AWSSDK.S3')}}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -14,12 +14,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
   </ItemGroup>
 
 </Project>

--- a/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
+++ b/src/CommandLineTests/NServiceBus.Transports.SQS.CommandLine.Tests.csproj
@@ -9,14 +9,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.3" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -12,15 +12,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.3" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="8.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -11,9 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.3" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
@@ -22,6 +19,18 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Particular.Approvals" Version="0.4.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -12,15 +12,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
     <PackageReference Include="BitFaster.Caching" Version="2.1.3" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.TransportTests.Sources" Version="8.0.3" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.115" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.50" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.104" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
AWS never broke compatibility and never caused issues in updates so far. It’s safe enough to auto merge dependencies