### PR TITLE
AWS SDK Client Cache hack removal 

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/ClientFactories.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/ClientFactories.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Transport.SQS.Tests
+﻿#nullable enable
+
+namespace NServiceBus.Transport.SQS.Tests
 {
     using System;
     using Amazon.Runtime;
@@ -8,44 +10,28 @@
 
     public static class ClientFactories
     {
-        public static IAmazonSQS CreateSqsClient(Action<AmazonSQSConfig> configure = default)
+        public static IAmazonSQS CreateSqsClient(Action<AmazonSQSConfig>? configure = default)
         {
             var credentials = new EnvironmentVariablesAWSCredentials();
-            var config = Create<AmazonSQSConfig>();
+            var config = new AmazonSQSConfig();
             configure?.Invoke(config);
             return new AmazonSQSClient(credentials, config);
         }
 
-        public static IAmazonSimpleNotificationService CreateSnsClient(Action<AmazonSimpleNotificationServiceConfig> configure = default)
+        public static IAmazonSimpleNotificationService CreateSnsClient(Action<AmazonSimpleNotificationServiceConfig>? configure = default)
         {
             var credentials = new EnvironmentVariablesAWSCredentials();
-            var config = Create<AmazonSimpleNotificationServiceConfig>();
+            var config = new AmazonSimpleNotificationServiceConfig();
             configure?.Invoke(config);
             return new AmazonSimpleNotificationServiceClient(credentials, config);
         }
 
-        public static IAmazonS3 CreateS3Client(Action<AmazonS3Config> configure = default)
+        public static IAmazonS3 CreateS3Client(Action<AmazonS3Config>? configure = default)
         {
             var credentials = new EnvironmentVariablesAWSCredentials();
-            var config = Create<AmazonS3Config>();
+            var config = new AmazonS3Config();
             configure?.Invoke(config);
             return new AmazonS3Client(credentials, config);
-        }
-
-        // Can be removed once https://github.com/aws/aws-sdk-net/issues/1929 is addressed by the team
-        // setting the cache size to 1 will significantly improve the throughput on non-windows OSS while
-        // windows had already 1 as the default.
-        // There might be other occurrences of setting this setting explicitly in the code base. Make sure to remove them
-        // consistently once the issue is addressed. 
-        static TConfig Create<TConfig>()
-            where TConfig : ClientConfig, new()
-        {
-#if NET
-            var config = new TConfig { HttpClientCacheSize = 1 };
-#else
-            var config = new TConfig();
-#endif
-            return config;
         }
     }
 }

--- a/src/NServiceBus.Transport.SQS/Configure/DefaultClientFactories.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/DefaultClientFactories.cs
@@ -3,34 +3,17 @@
 namespace NServiceBus
 {
     using System;
-    using Amazon.Runtime;
     using Amazon.S3;
     using Amazon.SimpleNotificationService;
     using Amazon.SQS;
 
     static class DefaultClientFactories
     {
-        public static Func<IAmazonSQS> SqsFactory = () => new AmazonSQSClient(Create<AmazonSQSConfig>());
+        public static Func<IAmazonSQS> SqsFactory = () => new AmazonSQSClient(new AmazonSQSConfig());
 
         public static Func<IAmazonSimpleNotificationService> SnsFactory = () =>
-            new AmazonSimpleNotificationServiceClient(Create<AmazonSimpleNotificationServiceConfig>());
+            new AmazonSimpleNotificationServiceClient(new AmazonSimpleNotificationServiceConfig());
 
-        public static Func<IAmazonS3> S3Factory = () => new AmazonS3Client(Create<AmazonS3Config>());
-
-        // Can be removed once https://github.com/aws/aws-sdk-net/issues/1929 is addressed by the team
-        // setting the cache size to 1 will significantly improve the throughput on non-windows OSS while
-        // windows had already 1 as the default.
-        // There might be other occurrences of setting this setting explicitly in the code base. Make sure to remove them
-        // consistently once the issue is addressed. 
-        static TConfig Create<TConfig>()
-            where TConfig : ClientConfig, new()
-        {
-#if NET
-            var config = new TConfig { HttpClientCacheSize = 1 };
-#else
-            var config = new TConfig();
-#endif
-            return config;
-        }
+        public static Func<IAmazonS3> S3Factory = () => new AmazonS3Client(new AmazonS3Config());
     }
 }

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.7.103.2, 3.8.0)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.101.3 , 3.8.0)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.7.100.67, 3.8.0)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7.104.1, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.101.52 , 3.8.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.100.116, 3.8.0)" />
     <PackageReference Include="BitFaster.Caching" Version="[2.1.1, 3.0.0)" />
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="Fody" Version="6.7.0" PrivateAssets="All" />


### PR DESCRIPTION
According to https://github.com/aws/aws-sdk-net/pull/2549#issuecomment-1500486145 the versions that target Version [3.7.106.15](https://www.nuget.org/packages/AWSSDK.Core/3.7.106.15) of Core should have the fix now applied and we can remove the hack.

Since any version or higher that targets that core version works I decided to bump to latest.