### PR TITLE
Group AWS dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 1000
+  groups:
+    awssdk:
+      patterns:
+        - "AWSSDK.*"
   ignore:
     # Particular.Analyzers updates are distributed via RepoStandards
     - dependency-name: "Particular.Analyzers"

--- a/.reposync.yml
+++ b/.reposync.yml
@@ -1,1 +1,2 @@
-
+exclusions:
+- .github/dependabot.yml


### PR DESCRIPTION
This repo is part of a GitHub private beta for grouped dependabot updates.

Temporarily removing dependabot from RepoSync otherwise it will try to undo the change to dependabot.yml.