### PR TITLE
Reduce logging output when stopping receivers

### DIFF
--- a/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
@@ -126,7 +126,7 @@ namespace NServiceBus.Transport.SQS
                 catch (Exception ex) when (ex.IsCausedBy(cancellationToken))
                 {
                     // private token, pump is being stopped, log the exception in case the stack trace is every required for debugging
-                    Logger.Debug("Operation canceled while stopping delayed message pump.", ex);
+                    Logger.Debug("Operation canceled while stopping delayed message pump.");
                     break;
                 }
                 catch (Exception ex)

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -213,7 +213,7 @@ namespace NServiceBus.Transport.SQS
                 catch (Exception ex) when (ex.IsCausedBy(messagePumpCancellationToken))
                 {
                     // private token, pump is being stopped, log exception in case stack trace is ever needed for debugging
-                    Logger.Debug("Operation canceled while stopping input queue pump.", ex);
+                    Logger.Debug("Operation canceled while stopping input queue pump.");
                     break;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Stopping receivers usually ends up in an OperationCancelledException from the passed cancellation token. This is fully expected behavior. However, the current implementation generates enormous amounts of log output due to the very long stack traces being logged. These stack traces aren't really relevant as they are expected and don't provide any useful information but make the CI output very noisy as the few (38) transport tests cause about 4k lines of log entries.