### PR TITLE
Use C# 12 collection expressions

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -28,7 +28,7 @@
     <Compile Include="..\NServiceBus.Transport.SQS.Tests\ClientFactories.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">
     <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\Routing\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
   </ItemGroup>
 

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -26,6 +26,9 @@
   <ItemGroup>
     <Compile Include="..\NServiceBus.Transport.SQS.Tests\Cleanup.cs" />
     <Compile Include="..\NServiceBus.Transport.SQS.Tests\ClientFactories.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(PkgNServiceBus_TransportTests_Sources)' != ''">
     <Compile Remove="$(PkgNServiceBus_TransportTests_Sources)\**\ExceptionExtensions.cs" />
   </ItemGroup>
 

--- a/src/NServiceBus.Transport.SQS/Configure/EventToEventsMappings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/EventToEventsMappings.cs
@@ -10,7 +10,7 @@
         {
             if (!eventsToEventsMappings.TryGetValue(subscribedEventType, out var mapping))
             {
-                mapping = new HashSet<Type>();
+                mapping = [];
                 eventsToEventsMappings.Add(subscribedEventType, mapping);
             }
 

--- a/src/NServiceBus.Transport.SQS/Configure/EventToTopicsMappings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/EventToTopicsMappings.cs
@@ -10,7 +10,7 @@
         {
             if (!eventsToTopicsMappings.TryGetValue(subscribedEventType, out var mapping))
             {
-                mapping = new HashSet<string>();
+                mapping = [];
                 eventsToTopicsMappings.Add(subscribedEventType, mapping);
             }
 


### PR DESCRIPTION
This change satisfies the new `IDE0028` analyzer rules in the .NET 8 SDK.

This PR also includes a fix for the build warnings from the compile items referencing the generated package path property.