### PR TITLE
Fix native integration when using localstack instead of real AWS cloud

### DIFF
--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -126,7 +126,7 @@ namespace NServiceBus.Transport.SQS
                 QueueUrl = inputQueueUrl,
                 WaitTimeSeconds = 20,
                 AttributeNames = new List<string> { "SentTimestamp" },
-                MessageAttributeNames = new List<string> { "*" }
+                MessageAttributeNames = new List<string> { ".*" }
             };
 
             if (coreSettings != null && coreSettings.TryGet<int>(SettingsKeys.MessageVisibilityTimeout, out var visibilityTimeout))


### PR DESCRIPTION
This PR fixes a bug that prevents native integration from working when using [localstack](https://github.com/localstack/localstack), a local AWS cloud stack implementation.

There is an undocumented feature (or perhaps an inconsistency) in the `MessageAttributeNames` parameter for `receiveMessage` in AWS.

The [official documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#receiveMessage-property) states that:

> you can return all of the attributes by specifying All or .* in your request

The undocumented feature is that AWS actually _also_ allows `*` to return all `MessageAttributes`.

`NServiceBus.AmazonSQS` [makes use](https://github.com/Particular/NServiceBus.AmazonSQS/blob/44acb865f0b34fd528808b65f61d3bea269f91e5/src/NServiceBus.Transport.SQS/InputQueuePump.cs#L129C15-L129C15) of this undocumented feature:

![image](https://github.com/Particular/NServiceBus.AmazonSQS/assets/46518526/8f267981-eaad-412b-a71b-00cc36a8fe17)

This works perfectly fine when working with the actual AWS cloud. But localstack seems to have written their implementation based on what the official AWS docs actually say, i.e. only `All` and `.*` (_not_ `*`*) will return all `MessageAttributes`. This means that even when you specify `MessageTypeFullName` to signal that it's a native message, the `InputQueuePump` doesn't see _any_ `MessageAttributes`, so it doesn't try to process it as a native message.

I think it makes sense to fix this in `NServiceBus.AmazonSQS` so that it doesn't rely on an undocumented feature. 

### Real AWS returns `MessageAttributes` for `*`, `.*` and `All`

![image](https://github.com/Particular/NServiceBus.AmazonSQS/assets/46518526/79fc2894-6941-482b-9491-7a84e2258cdc)
![image](https://github.com/Particular/NServiceBus.AmazonSQS/assets/46518526/66fcb523-9fd0-401b-bf15-ef9181ca0a2a)
![image](https://github.com/Particular/NServiceBus.AmazonSQS/assets/46518526/77025c3a-4129-4076-a74c-e8f3df2b1bda)

### Localstack doesn't return `MessageAttributes` for `*`, but does for `.*` and `All`

![image](https://github.com/Particular/NServiceBus.AmazonSQS/assets/46518526/da230d81-2e60-47e5-afad-113c9addc37d)
![image](https://github.com/Particular/NServiceBus.AmazonSQS/assets/46518526/b25a613f-f242-48fd-997c-7cbbba052138)
![image](https://github.com/Particular/NServiceBus.AmazonSQS/assets/46518526/e78dca3d-fd14-4c53-83d2-3e908f051bd0)

