### PR TITLE
[Backport to 5.7] Use wildcard format as documented by AWS to fix native integration when using localstack instead of real AWS cloud

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/NativeEndpoint.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/NativeEndpoint.cs
@@ -32,7 +32,7 @@
                     {
                         QueueUrl = getQueueUrlResponse.QueueUrl,
                         WaitTimeSeconds = 5,
-                        MessageAttributeNames = new List<string> { "*" }
+                        MessageAttributeNames = new List<string> { "All" }
                     }, cancellationToken).ConfigureAwait(false);
 
                     foreach (var msg in receiveMessageResponse.Messages)

--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.Transport.SQS.Tests
 
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MaxNumberOfMessages == 1), "MaxNumberOfMessages did not match");
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.QueueUrl == FakeInputQueueQueueUrl), "QueueUrl did not match");
-            Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageAttributeNames.SequenceEqual(new List<string> { "*" })), "MessageAttributeNames did not match");
+            Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageAttributeNames.SequenceEqual(new List<string> { "All" })), "MessageAttributeNames did not match");
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.AttributeNames.SequenceEqual(new List<string> { "SentTimestamp" })), "AttributeNames did not match");
         }
 

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -81,7 +81,7 @@ namespace NServiceBus.Transport.SQS
                 QueueUrl = inputQueueUrl,
                 WaitTimeSeconds = 20,
                 AttributeNames = new List<string> { "SentTimestamp" },
-                MessageAttributeNames = new List<string> { "*" },
+                MessageAttributeNames = new List<string> { "All" }
             };
             //Set visibilitytimeout only when explicitly set by user configuration, else take the value in the queue
             //users can define a custom visibility timeout only when using message driven pub/sub compatibility mode


### PR DESCRIPTION
- _Backport to 6.1 of #2289_

This PR fixes a bug that prevents native integration from working when using [localstack](https://github.com/localstack/localstack), a local AWS cloud stack implementation.

More information in https://github.com/Particular/NServiceBus.AmazonSQS/pull/2288