### PR TITLE
Detect non-idempotent custom queue name generator

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/QueueNameGeneratorTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/QueueNameGeneratorTests.cs
@@ -21,22 +21,30 @@
         [Test]
         public void Idempotent_custom_queue_name_generator_is_accepted()
         {
-            var transport = new SqsTransport();
-
-            Assert.DoesNotThrow(() =>
+            var transport = new SqsTransport
             {
-                transport.QueueNameGenerator = IdempotentQueueNameGenerator;
+                QueueNameGenerator = IdempotentQueueNameGenerator
+            };
+            var hostSettings = new HostSettings("name", "displayName", new StartupDiagnosticEntries(), (_, __, ___) => { }, false);
+
+
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await transport.Initialize(hostSettings, Array.Empty<ReceiveSettings>(), Array.Empty<string>());
             }, "A custom queue name generator that is idempotent should be accepted.");
         }
 
         [Test]
         public void Non_idempotent_custom_queue_name_generator_throws()
         {
-            var transport = new SqsTransport();
-
-            Assert.Throws<Exception>(() =>
+            var transport = new SqsTransport
             {
-                transport.QueueNameGenerator = NonIdempotentQueueNameGenerator;
+                QueueNameGenerator = NonIdempotentQueueNameGenerator
+            };
+
+            Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await transport.Initialize(null, null, null);
             }, "A custom queue name generator that is not idempotent should throw an exception.");
         }
 

--- a/src/NServiceBus.Transport.SQS.Tests/QueueNameGeneratorTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/QueueNameGeneratorTests.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.Transport.SQS.Tests
+{
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class QueueNameGeneratorTests
+    {
+        [Test]
+        public void Default_queue_name_generator_is_idempotent()
+        {
+            const string prefix = "Prefix";
+            const string destination = "Destination";
+
+            var once = QueueCache.GetSqsQueueName(destination, prefix);
+            var twice = QueueCache.GetSqsQueueName(once, prefix);
+
+            Assert.That(twice, Is.EqualTo(once), "Applying the default queue name generator twice should impact the outcome");
+        }
+
+        [Test]
+        public void Idempotent_custom_queue_name_generator_is_accepted()
+        {
+            var transport = new SqsTransport();
+
+            Assert.DoesNotThrow(() =>
+            {
+                transport.QueueNameGenerator = IdempotentQueueNameGenerator;
+            }, "A custom queue name generator that is idempotent should be accepted.");
+        }
+
+        [Test]
+        public void Non_idempotent_custom_queue_name_generator_throws()
+        {
+            var transport = new SqsTransport();
+
+            Assert.Throws<Exception>(() =>
+            {
+                transport.QueueNameGenerator = NonIdempotentQueueNameGenerator;
+            }, "A custom queue name generator that is not idempotent should throw an exception.");
+        }
+
+        static string IdempotentQueueNameGenerator(string destination, string prefix)
+        {
+            if (destination.StartsWith(prefix))
+            {
+                return destination;
+            }
+            return $"{prefix}{destination}";
+        }
+
+        static string NonIdempotentQueueNameGenerator(string destination, string prefix)
+        {
+            return $"{prefix}{destination}";
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -272,7 +272,7 @@
             var twice = generator(once, prefix);
             if (once != twice)
             {
-                throw new Exception($"Queue name generator is not idempotent. Result of applying twice {twice}");
+                throw new Exception($"The queue name generator function needs to return the same result when it is applied multiple times (idempotent). Result of applying once is {once} and twice -- {twice}.");
             }
         }
 

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -67,7 +67,21 @@
             set
             {
                 Guard.ThrowIfNull(value);
+                AssertQueueNameGeneratorIdempotent(value);
                 queueNameGenerator = value;
+            }
+        }
+
+        static void AssertQueueNameGeneratorIdempotent(Func<string, string, string> generator)
+        {
+            const string prefix = "Prefix";
+            const string destination = "Destination";
+
+            var once = generator(destination, prefix);
+            var twice = generator(once, prefix);
+            if (once != twice)
+            {
+                throw new Exception($"Queue name generator is not idempotent. Result of applying twice {twice}");
             }
         }
 


### PR DESCRIPTION
- Partially addresses #2314

It is possible that the queue name generator may be applied multiple times. The default queue name generator is idempotent (see test in the PR) but a custom one may not be. This can lead to incorrect results when a custom queue name generator has been applied.

This PR adds a validation check when the custom queue name generator is set to ensure that applying it twice is safe.