### PR TITLE
Add message extraction tests

### DIFF
--- a/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text.Json;
     using Amazon.SQS.Model;
     using NServiceBus;
@@ -15,152 +16,173 @@
         {
             get
             {
-                var nsbMessageId = Guid.NewGuid().ToString("N");
-
-                yield return TestCase("Only native message Id");
-
-                yield return TestCase("NSB Message Id in Message Attributes",
-                    native => native.WithMessageAttribute(Headers.MessageId, nsbMessageId),
-                    expectedMessageId: nsbMessageId);
-
-                yield return TestCase(
-                    "Passing headers via dedicated message attribute",
-                    native => native.WithMessageAttribute(
-                        TransportHeaders.Headers,
-                              @"{
-                                    ""SomeKey"": ""SomeValue""
-                                }"),
-                    transport => transport.WithHeader("SomeKey", "SomeValue")
-                );
-
-                yield return TestCase(
-                    "Passing headers and S3 Body key via dedicated message attributes",
-                    native => native
-                        .WithMessageAttribute(TransportHeaders.Headers, "{}")
-                        .WithMessageAttribute(TransportHeaders.S3BodyKey, "SomeS3BodyKey"),
-                    transport => transport
-                        .WithHeader(TransportHeaders.S3BodyKey, "SomeS3BodyKey")
-                        .WithS3BodyKey("SomeS3BodyKey")
-                );
-
-                yield return TestCase(
-                    "Passing message type full name as message attribute",
-                    native => native
-                        .WithMessageAttribute(TransportHeaders.MessageTypeFullName, "SomeTypeName")
-                        .WithBody("Message Body"),
-                    transport => transport
-                        .WithHeader(Headers.EnclosedMessageTypes, "SomeTypeName")
-                        .WithHeader(TransportHeaders.MessageTypeFullName, "SomeTypeName")
-                        .WithBody("Message Body")
-                );
-
-                yield return TestCase(
-                    "Passing message type full name and S3 body key as message attribute",
-                    native => native
-                        .WithMessageAttribute(TransportHeaders.MessageTypeFullName, "SomeTypeName")
-                        .WithMessageAttribute(TransportHeaders.S3BodyKey, "S3 Body Key")
-                        .WithBody("Message Body"),
-                    transport => transport
-                        .WithHeader(Headers.EnclosedMessageTypes, "SomeTypeName")
-                        .WithHeader(TransportHeaders.S3BodyKey, "S3 Body Key")
-                        .WithHeader(TransportHeaders.MessageTypeFullName, "SomeTypeName")
-                        .WithS3BodyKey("S3 Body Key")
-                        .WithBody("Message Body")
-                );
-
-                yield return TestCase(
-                    "Serialized Transport message with enclosed message type header",
-                    native => native
-                        .WithBody(
-                            $@"{{
-                                ""Body"": ""Body"",
-                                ""Headers"": {{
-                                    ""{Headers.EnclosedMessageTypes}"": ""SomeType"",
-                                    ""SomeKey"": ""SomeValue""
-                                }}
-                              }}"
-                        ),
-                    transport => transport
-                        .WithHeader("SomeKey", "SomeValue")
-                        .WithHeader(Headers.EnclosedMessageTypes, "SomeType")
-                        .WithBody("Body")
-                );
-
-                yield return TestCase(
-                    "Serialized Transport message with message id header",
-                    native => native
-                        .WithBody(
-                            $@"{{
-                                ""Body"": ""Body"",
-                                ""Headers"": {{
-                                    ""{Headers.MessageId}"": ""{nsbMessageId}"",
-                                    ""SomeKey"": ""SomeValue""
-                                }}
-                              }}"
-                        ),
-                    transport => transport
-                        .WithHeader("SomeKey", "SomeValue")
-                        .WithBody("Body"),
-                    expectedMessageId: nsbMessageId
-                );
-
-                yield return TestCase(
-                    "Serialized Transport message with control message header",
-                    native => native
-                        // NOTE: The value is case sensitive
-                        // TODO: Should it be?
-                        .WithBody($@"{{
-                            ""Headers"": {{
-                                ""{Headers.ControlMessageHeader}"": ""True""
-                            }}
-                        }}"),
-                    transport => transport
-                        .WithHeader(Headers.ControlMessageHeader, "True")
-                );
-
-                var serializedTransportMessageWithoutHeaders = @"{
-    ""Body"": ""Message Body""
-}";
-                yield return TestCase(
-                    "Serialized transport message without headers",
-                    native => native
-                        .WithBody(serializedTransportMessageWithoutHeaders),
-                    transport => transport
-                        .WithBody(serializedTransportMessageWithoutHeaders)
-                );
-
-
-                var pureNativeBody = @"{
-    ""SomeKey"": ""SomeValue""
-}";
-
-                yield return TestCase(
-                    "Pure native message",
-                    native => native
-                        .WithBody(pureNativeBody),
-                    transport => transport.WithBody(pureNativeBody)
-                );
-
-                TestCaseData TestCase(string name, Action<NativeMessageBuilder> native = null, Action<TransportMessageBuilder> transport = null, string expectedMessageId = null)
+                foreach (var passMessageIdInMessageAttribute in new[] { true, false })
                 {
-                    var nativeMessageId = Guid.NewGuid().ToString();
-                    var messageBuilder = new NativeMessageBuilder(nativeMessageId);
-                    native?.Invoke(messageBuilder);
-                    var transportMessageBuilder = new TransportMessageBuilder();
-                    transportMessageBuilder.WithHeader(Headers.MessageId, expectedMessageId ?? nativeMessageId);
-                    transport?.Invoke(transportMessageBuilder);
-
-                    return new TestCaseData(
-                        messageBuilder.Build(),
-                        transportMessageBuilder.Build()
-                    ).SetName(name);
+                    foreach (var passMessageIdInNsbHeaders in new[] { true, false })
+                    {
+                        foreach (var pushBodyToS3 in new[] { true, false })
+                        {
+                            foreach (var testCase in GenerateTestCases(passMessageIdInMessageAttribute, passMessageIdInNsbHeaders, pushBodyToS3))
+                            {
+                                yield return testCase;
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        [Test, TestCaseSource(nameof(TestCases))]
-        public void ExtractsMessageCorrectly(Message message, TransportMessage expectedTransportMessage)
+        static IEnumerable<TestCaseData> GenerateTestCases(bool passMessageIdInMessageAttribute, bool passMessageIdInNsbHeaders, bool pushBodyToS3)
         {
+            var nativeMessageId = "Native message Id";
+            var nsbMessageIdPassedThroughMessageAttribute = "NSB Message Id passed via message attribute";
+            var nsbMessageIdPassedThroughHeaders = "NSB Message Id passed via headers";
+            bool passBodyInMessage = !pushBodyToS3;
+
+            #region NSB headers in message attribute tests
+            yield return TestCase(
+                "Transport headers in message attribute",
+                native => native
+                    .WithMessageAttributeHeader(TransportHeaders.S3BodyKey, "Will be overwritten", condition: pushBodyToS3)
+                    .WithMessageAttributeHeader("SomeKey", "SomeValue")
+                    .WithMessageAttributeHeader(Headers.MessageId, "Will be overwritten", condition: passMessageIdInNsbHeaders)
+                    .WithMessageAttribute(TransportHeaders.S3BodyKey, "S3 Body Key", condition: pushBodyToS3)
+                    .WithBody("Body Contents", condition: passBodyInMessage),
+                transport => transport
+                    // HINT: Message Id from headers is going to get overwritten no matter what
+                    .WithHeader(Headers.MessageId, nativeMessageId)
+                    .WithHeader(Headers.MessageId, nsbMessageIdPassedThroughMessageAttribute, condition: passMessageIdInMessageAttribute)
+                    .WithHeader("SomeKey", "SomeValue")
+                    .WithBody("Body Contents", condition: passBodyInMessage)
+                    .WithHeader(TransportHeaders.S3BodyKey, "S3 Body Key", condition: pushBodyToS3)
+                    .WithS3BodyKey("S3 Body Key", condition: pushBodyToS3)
+            );
+
+            yield return TestCase(
+                "Corrupted headers in message attribute",
+                native => native.WithMessageAttribute(TransportHeaders.Headers, "NOT JSON DICTIONARY"),
+                considerPoison: true);
+
+            #endregion
+
+            #region Message type in message attribute tests
+            yield return TestCase(
+                "Message type in message attributes",
+                native => native
+                    .WithMessageAttribute(TransportHeaders.MessageTypeFullName, "Message type full name")
+                    .WithMessageAttribute(TransportHeaders.S3BodyKey, "S3 body key", condition: pushBodyToS3)
+                    .WithBody("Body Contents", condition: passBodyInMessage),
+                transport => transport
+                    .WithHeader(TransportHeaders.MessageTypeFullName, "Message type full name")
+                    .WithHeader(Headers.EnclosedMessageTypes, "Message type full name")
+                    .WithBody("Body Contents", condition: passBodyInMessage)
+                    .WithHeader(TransportHeaders.S3BodyKey, "S3 body key", condition: pushBodyToS3)
+                    .WithS3BodyKey("S3 body key", condition: pushBodyToS3),
+                // HINT: There is no way to pass this via headers. It should fall back to native message id
+                expectedMessageId: passMessageIdInNsbHeaders && !passMessageIdInMessageAttribute ? nativeMessageId : null
+            );
+            #endregion
+
+            #region Serialized transport message tests
+            var senderTransportMessage = new TransportMessageBuilder()
+                .WithHeader(Headers.MessageId, nsbMessageIdPassedThroughHeaders, condition: passMessageIdInNsbHeaders)
+                .WithBody("Body Contents", condition: passBodyInMessage)
+                .WithS3BodyKey("S3 Body Key", condition: pushBodyToS3)
+                .Build();
+
+            yield return TestCase(
+                "Serialized transport message",
+                native => native
+                    .WithBody(JsonSerializer.Serialize(senderTransportMessage)),
+                transport => transport
+                    // HINT: This is needed here because the serializer reads it and it gets a default (MAX). When it is deserialized it gets included
+                    .WithHeader(TransportHeaders.TimeToBeReceived, TimeSpan.MaxValue.ToString())
+                    // HINT: If the message id is passed via headers then it is used, otherwise no message id is set
+                    .WithHeader(Headers.MessageId, nsbMessageIdPassedThroughHeaders, condition: passMessageIdInNsbHeaders)
+                    .WithBody("Body Contents", condition: passBodyInMessage)
+                    .WithS3BodyKey("S3 Body Key", condition: pushBodyToS3)
+            );
+
+            #region Corrupted transport message tests
+            // HINT: These should all throw
+            yield return TestCase(
+                "Corrupted serialized transport message no headers",
+                native => native.WithBody(@"{
+                                                ""Body"": ""Body Contents""
+                                            }"),
+                considerPoison: true
+            );
+
+            yield return TestCase(
+                "Fully corrupted serialized transport message",
+                native => native
+                    .WithBody(@"{
+                                    ""NonExistingProperty"": ""Does not matter""
+                                }"),
+                considerPoison: true
+            );
+
+            yield return TestCase(
+                "Corrupted headers on serialized transport message",
+                native => native
+                    .WithBody(@"{
+                                    ""Headers"": ""NOT A JSON DICTIONARY""
+                                }"),
+                considerPoison: true
+            );
+
+            // TODO: Add more test cases with malformed transport message objects
+            #endregion
+
+            #endregion
+
+            TestCaseData TestCase(
+                string name,
+                Action<NativeMessageBuilder> native = null,
+                Action<TransportMessageBuilder> transport = null,
+                bool considerPoison = false,
+                string expectedMessageId = null)
+            {
+                var messageBuilder = new NativeMessageBuilder(nativeMessageId)
+                    .WithMessageAttribute(Headers.MessageId, nsbMessageIdPassedThroughMessageAttribute, passMessageIdInMessageAttribute);
+
+                native?.Invoke(messageBuilder);
+
+                var transportMessageBuilder = new TransportMessageBuilder()
+                    // HINT: Last in wins
+                    .WithHeader(Headers.MessageId, nativeMessageId)
+                    .WithHeader(Headers.MessageId, nsbMessageIdPassedThroughHeaders, condition: passMessageIdInNsbHeaders)
+                    .WithHeader(Headers.MessageId, nsbMessageIdPassedThroughMessageAttribute, condition: passMessageIdInMessageAttribute)
+                    .WithHeader(Headers.MessageId, expectedMessageId, condition: expectedMessageId != null);
+
+                transport?.Invoke(transportMessageBuilder);
+
+                var testCaseName = name;
+                testCaseName += passMessageIdInMessageAttribute ? " - Message Id in message attribute" : " - Message Id NOT in message attribute";
+                testCaseName += passMessageIdInNsbHeaders ? " - NSB message Id provided" : " - NSB message Id NOT provided";
+                testCaseName += pushBodyToS3 ? " - body in S3" : " - body on message";
+
+                return new TestCaseData(
+                    messageBuilder.Build(),
+                    transportMessageBuilder.Build(),
+                    considerPoison
+                ).SetName(testCaseName);
+            }
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void ExtractsMessageCorrectly(Message message, TransportMessage expectedTransportMessage, bool considerPoison)
+        {
+            if (considerPoison)
+            {
+                Assert.Throws(
+                    Is.InstanceOf<Exception>(),
+                    () => InputQueuePump.ExtractTransportMessage(message),
+                    "This case is not supported. Message should be treated as poison."
+                );
+                return;
+            }
+
             var transportMessage = InputQueuePump.ExtractTransportMessage(message);
             Assert.That(transportMessage, Is.Not.Null, "TransportMessage should be set");
             Assert.That(transportMessage.Headers, Is.Not.Null, "Headers should be set");
@@ -170,47 +192,60 @@
             // TODO: Handle ReplyToAddress and TimeToBeReceived
             //Assert.That(transportMessage.ReplyToAddress)
             //Assert.That(transportMessage.TimeToBeReceived)
+
             Assert.That(transportMessage.Headers, Is.EquivalentTo(expectedTransportMessage.Headers), "Headers are not set correctly");
-
-        }
-
-        [Test]
-        public void Throws_if_headers_message_attribute_is_not_json()
-        {
-            var nativeMessageId = Guid.NewGuid().ToString("N");
-
-            var message = new NativeMessageBuilder(nativeMessageId)
-                .WithMessageAttribute(TransportHeaders.Headers, "NOT JSON")
-                .Build();
-
-            Assert.Throws<JsonException>(
-                () => InputQueuePump.ExtractTransportMessage(message),
-                "Should throw an exception if the header message attribute is not json"
-            );
         }
 
         class NativeMessageBuilder
         {
             Message message;
+            Dictionary<string, string> headers = [];
 
             public NativeMessageBuilder(string nativeMessageId)
             {
                 message = new Message { MessageId = nativeMessageId };
             }
 
-            public NativeMessageBuilder WithMessageAttribute(string key, string value)
+            public NativeMessageBuilder WithMessageAttributeHeader(string key, string value, bool condition = true)
             {
-                message.MessageAttributes[key] = new MessageAttributeValue { StringValue = value };
+                if (condition)
+                {
+                    headers[key] = value;
+                }
                 return this;
             }
 
-            public NativeMessageBuilder WithBody(string body)
+            public NativeMessageBuilder WithMessageAttribute(string key, string value, bool condition = true)
             {
-                message.Body = body;
+                if (condition)
+                {
+                    message.MessageAttributes[key] = new MessageAttributeValue { StringValue = value };
+                }
                 return this;
             }
 
-            public Message Build() => message;
+            public NativeMessageBuilder WithBody(string body, bool condition = true)
+            {
+                if (condition)
+                {
+                    message.Body = body;
+                }
+                return this;
+            }
+
+            public Message Build()
+            {
+                if (headers.Any())
+                {
+                    var serialized = JsonSerializer.Serialize(headers);
+                    message.MessageAttributes.Add(TransportHeaders.Headers, new MessageAttributeValue
+                    {
+                        StringValue = serialized
+                    });
+                    ;
+                }
+                return message;
+            }
         }
 
         class TransportMessageBuilder
@@ -220,21 +255,30 @@
                 Headers = []
             };
 
-            public TransportMessageBuilder WithHeader(string key, string value)
+            public TransportMessageBuilder WithHeader(string key, string value, bool condition = true)
             {
-                message.Headers[key] = value;
+                if (condition)
+                {
+                    message.Headers[key] = value;
+                }
                 return this;
             }
 
-            public TransportMessageBuilder WithBody(string body)
+            public TransportMessageBuilder WithBody(string body, bool condition = true)
             {
-                message.Body = body;
+                if (condition)
+                {
+                    message.Body = body;
+                }
                 return this;
             }
 
-            public TransportMessageBuilder WithS3BodyKey(string key)
+            public TransportMessageBuilder WithS3BodyKey(string key, bool condition = true)
             {
-                message.S3BodyKey = key;
+                if (condition)
+                {
+                    message.S3BodyKey = key;
+                }
                 return this;
             }
 

--- a/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
@@ -1,0 +1,244 @@
+﻿namespace TransportTests.TransportMessageExtraction
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json;
+    using Amazon.SQS.Model;
+    using NServiceBus;
+    using NServiceBus.Transport.SQS;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class MessageExtractionTests
+    {
+        static IEnumerable<TestCaseData> TestCases
+        {
+            get
+            {
+                var nsbMessageId = Guid.NewGuid().ToString("N");
+
+                yield return TestCase("Only native message Id");
+
+                yield return TestCase("NSB Message Id in Message Attributes",
+                    native => native.WithMessageAttribute(Headers.MessageId, nsbMessageId),
+                    expectedMessageId: nsbMessageId);
+
+                yield return TestCase(
+                    "Passing headers via dedicated message attribute",
+                    native => native.WithMessageAttribute(
+                        TransportHeaders.Headers,
+                              @"{
+                                    ""SomeKey"": ""SomeValue""
+                                }"),
+                    transport => transport.WithHeader("SomeKey", "SomeValue")
+                );
+
+                yield return TestCase(
+                    "Passing headers and S3 Body key via dedicated message attributes",
+                    native => native
+                        .WithMessageAttribute(TransportHeaders.Headers, "{}")
+                        .WithMessageAttribute(TransportHeaders.S3BodyKey, "SomeS3BodyKey"),
+                    transport => transport
+                        .WithHeader(TransportHeaders.S3BodyKey, "SomeS3BodyKey")
+                        .WithS3BodyKey("SomeS3BodyKey")
+                );
+
+                yield return TestCase(
+                    "Passing message type full name as message attribute",
+                    native => native
+                        .WithMessageAttribute(TransportHeaders.MessageTypeFullName, "SomeTypeName")
+                        .WithBody("Message Body"),
+                    transport => transport
+                        .WithHeader(Headers.EnclosedMessageTypes, "SomeTypeName")
+                        .WithHeader(TransportHeaders.MessageTypeFullName, "SomeTypeName")
+                        .WithBody("Message Body")
+                );
+
+                yield return TestCase(
+                    "Passing message type full name and S3 body key as message attribute",
+                    native => native
+                        .WithMessageAttribute(TransportHeaders.MessageTypeFullName, "SomeTypeName")
+                        .WithMessageAttribute(TransportHeaders.S3BodyKey, "S3 Body Key")
+                        .WithBody("Message Body"),
+                    transport => transport
+                        .WithHeader(Headers.EnclosedMessageTypes, "SomeTypeName")
+                        .WithHeader(TransportHeaders.S3BodyKey, "S3 Body Key")
+                        .WithHeader(TransportHeaders.MessageTypeFullName, "SomeTypeName")
+                        .WithS3BodyKey("S3 Body Key")
+                        .WithBody("Message Body")
+                );
+
+                yield return TestCase(
+                    "Serialized Transport message with enclosed message type header",
+                    native => native
+                        .WithBody(
+                            $@"{{
+                                ""Body"": ""Body"",
+                                ""Headers"": {{
+                                    ""{Headers.EnclosedMessageTypes}"": ""SomeType"",
+                                    ""SomeKey"": ""SomeValue""
+                                }}
+                              }}"
+                        ),
+                    transport => transport
+                        .WithHeader("SomeKey", "SomeValue")
+                        .WithHeader(Headers.EnclosedMessageTypes, "SomeType")
+                        .WithBody("Body")
+                );
+
+                yield return TestCase(
+                    "Serialized Transport message with message id header",
+                    native => native
+                        .WithBody(
+                            $@"{{
+                                ""Body"": ""Body"",
+                                ""Headers"": {{
+                                    ""{Headers.MessageId}"": ""{nsbMessageId}"",
+                                    ""SomeKey"": ""SomeValue""
+                                }}
+                              }}"
+                        ),
+                    transport => transport
+                        .WithHeader("SomeKey", "SomeValue")
+                        .WithBody("Body"),
+                    expectedMessageId: nsbMessageId
+                );
+
+                yield return TestCase(
+                    "Serialized Transport message with control message header",
+                    native => native
+                        // NOTE: The value is case sensitive
+                        // TODO: Should it be?
+                        .WithBody($@"{{
+                            ""Headers"": {{
+                                ""{Headers.ControlMessageHeader}"": ""True""
+                            }}
+                        }}"),
+                    transport => transport
+                        .WithHeader(Headers.ControlMessageHeader, "True")
+                );
+
+                var serializedTransportMessageWithoutHeaders = @"{
+    ""Body"": ""Message Body""
+}";
+                yield return TestCase(
+                    "Serialized transport message without headers",
+                    native => native
+                        .WithBody(serializedTransportMessageWithoutHeaders),
+                    transport => transport
+                        .WithBody(serializedTransportMessageWithoutHeaders)
+                );
+
+
+                var pureNativeBody = @"{
+    ""SomeKey"": ""SomeValue""
+}";
+
+                yield return TestCase(
+                    "Pure native message",
+                    native => native
+                        .WithBody(pureNativeBody),
+                    transport => transport.WithBody(pureNativeBody)
+                );
+
+                TestCaseData TestCase(string name, Action<NativeMessageBuilder> native = null, Action<TransportMessageBuilder> transport = null, string expectedMessageId = null)
+                {
+                    var nativeMessageId = Guid.NewGuid().ToString();
+                    var messageBuilder = new NativeMessageBuilder(nativeMessageId);
+                    native?.Invoke(messageBuilder);
+                    var transportMessageBuilder = new TransportMessageBuilder();
+                    transportMessageBuilder.WithHeader(Headers.MessageId, expectedMessageId ?? nativeMessageId);
+                    transport?.Invoke(transportMessageBuilder);
+
+                    return new TestCaseData(
+                        messageBuilder.Build(),
+                        transportMessageBuilder.Build()
+                    ).SetName(name);
+                }
+            }
+        }
+
+        [Test, TestCaseSource(nameof(TestCases))]
+        public void ExtractsMessageCorrectly(Message message, TransportMessage expectedTransportMessage)
+        {
+            var transportMessage = InputQueuePump.ExtractTransportMessage(message);
+            Assert.That(transportMessage, Is.Not.Null, "TransportMessage should be set");
+            Assert.That(transportMessage.Headers, Is.Not.Null, "Headers should be set");
+
+            Assert.That(transportMessage.Body, Is.EqualTo(expectedTransportMessage.Body), "Body is not set correctly");
+            Assert.That(transportMessage.S3BodyKey, Is.EqualTo(expectedTransportMessage.S3BodyKey), "S3 Body Key is not set correctly");
+            // TODO: Handle ReplyToAddress and TimeToBeReceived
+            //Assert.That(transportMessage.ReplyToAddress)
+            //Assert.That(transportMessage.TimeToBeReceived)
+            Assert.That(transportMessage.Headers, Is.EquivalentTo(expectedTransportMessage.Headers), "Headers are not set correctly");
+
+        }
+
+        [Test]
+        public void Throws_if_headers_message_attribute_is_not_json()
+        {
+            var nativeMessageId = Guid.NewGuid().ToString("N");
+
+            var message = new NativeMessageBuilder(nativeMessageId)
+                .WithMessageAttribute(TransportHeaders.Headers, "NOT JSON")
+                .Build();
+
+            Assert.Throws<JsonException>(
+                () => InputQueuePump.ExtractTransportMessage(message),
+                "Should throw an exception if the header message attribute is not json"
+            );
+        }
+
+        class NativeMessageBuilder
+        {
+            Message message;
+
+            public NativeMessageBuilder(string nativeMessageId)
+            {
+                message = new Message { MessageId = nativeMessageId };
+            }
+
+            public NativeMessageBuilder WithMessageAttribute(string key, string value)
+            {
+                message.MessageAttributes[key] = new MessageAttributeValue { StringValue = value };
+                return this;
+            }
+
+            public NativeMessageBuilder WithBody(string body)
+            {
+                message.Body = body;
+                return this;
+            }
+
+            public Message Build() => message;
+        }
+
+        class TransportMessageBuilder
+        {
+            TransportMessage message = new TransportMessage
+            {
+                Headers = []
+            };
+
+            public TransportMessageBuilder WithHeader(string key, string value)
+            {
+                message.Headers[key] = value;
+                return this;
+            }
+
+            public TransportMessageBuilder WithBody(string body)
+            {
+                message.Body = body;
+                return this;
+            }
+
+            public TransportMessageBuilder WithS3BodyKey(string key)
+            {
+                message.S3BodyKey = key;
+                return this;
+            }
+
+            public TransportMessage Build() => message;
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
@@ -173,17 +173,28 @@
         [TestCaseSource(nameof(TestCases))]
         public void ExtractsMessageCorrectly(Message message, TransportMessage expectedTransportMessage, bool considerPoison)
         {
+            //Copy of the logic of ProcessMessage
+            string messageId;
+            if (message.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute))
+            {
+                messageId = messageIdAttribute.StringValue;
+            }
+            else
+            {
+                messageId = message.MessageId;
+            }
+
             if (considerPoison)
             {
                 Assert.Throws(
                     Is.InstanceOf<Exception>(),
-                    () => InputQueuePump.ExtractTransportMessage(message),
+                    () => InputQueuePump.ExtractTransportMessage(message, messageId),
                     "This case is not supported. Message should be treated as poison."
                 );
                 return;
             }
 
-            var transportMessage = InputQueuePump.ExtractTransportMessage(message);
+            var transportMessage = InputQueuePump.ExtractTransportMessage(message, messageId);
             Assert.That(transportMessage, Is.Not.Null, "TransportMessage should be set");
             Assert.That(transportMessage.Headers, Is.Not.Null, "Headers should be set");
 

--- a/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/TransportMessageExtraction/MessageExtractionTests.cs
@@ -173,17 +173,7 @@
         [TestCaseSource(nameof(TestCases))]
         public void ExtractsMessageCorrectly(Message message, TransportMessage expectedTransportMessage, bool considerPoison)
         {
-            //Copy of the logic of ProcessMessage
-            string messageId;
-            if (message.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute))
-            {
-                messageId = messageIdAttribute.StringValue;
-            }
-            else
-            {
-                messageId = message.MessageId;
-            }
-
+            var messageId = InputQueuePump.ExtractMessageId(message);
             if (considerPoison)
             {
                 Assert.Throws(

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -280,15 +280,7 @@ namespace NServiceBus.Transport.SQS
 
             try
             {
-                string messageId;
-                if (receivedMessage.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute))
-                {
-                    messageId = messageIdAttribute.StringValue;
-                }
-                else
-                {
-                    messageId = nativeMessageId;
-                }
+                var messageId = ExtractMessageId(receivedMessage);
 
                 try
                 {
@@ -343,6 +335,14 @@ namespace NServiceBus.Transport.SQS
                     arrayPool.Return(messageBodyBuffer, clearArray: true);
                 }
             }
+        }
+
+
+        public static string ExtractMessageId(Message receivedMessage)
+        {
+            return receivedMessage.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute)
+                ? messageIdAttribute.StringValue
+                : receivedMessage.MessageId;
         }
 
         public static TransportMessage ExtractTransportMessage(Message receivedMessage, string messageIdOverride)


### PR DESCRIPTION
Moves the message extraction tests logic from https://github.com/Particular/NServiceBus.AmazonSQS/pull/2331 to `master`