### PR TITLE
[Backport to 6.2] Detect non-idempotent custom queue name generator (#2321)

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/QueueNameGeneratorTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/QueueNameGeneratorTests.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.Transport.SQS.Tests
+{
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class QueueNameGeneratorTests
+    {
+        [Test]
+        public void Default_queue_name_generator_is_idempotent()
+        {
+            const string prefix = "Prefix";
+            const string destination = "Destination";
+
+            var once = QueueCache.GetSqsQueueName(destination, prefix);
+            var twice = QueueCache.GetSqsQueueName(once, prefix);
+
+            Assert.That(twice, Is.EqualTo(once), "Applying the default queue name generator twice should impact the outcome");
+        }
+
+        [Test]
+        public void Idempotent_custom_queue_name_generator_is_accepted()
+        {
+            var transport = new SqsTransport
+            {
+                QueueNameGenerator = IdempotentQueueNameGenerator
+            };
+            var hostSettings = new HostSettings("name", "displayName", new StartupDiagnosticEntries(), (_, __, ___) => { }, false);
+
+
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await transport.Initialize(hostSettings, Array.Empty<ReceiveSettings>(), Array.Empty<string>());
+            }, "A custom queue name generator that is idempotent should be accepted.");
+        }
+
+        [Test]
+        public void Non_idempotent_custom_queue_name_generator_throws()
+        {
+            var transport = new SqsTransport
+            {
+                QueueNameGenerator = NonIdempotentQueueNameGenerator
+            };
+
+            Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await transport.Initialize(null, null, null);
+            }, "A custom queue name generator that is not idempotent should throw an exception.");
+        }
+
+        static string IdempotentQueueNameGenerator(string destination, string prefix)
+        {
+            if (destination.StartsWith(prefix))
+            {
+                return destination;
+            }
+            return $"{prefix}{destination}";
+        }
+
+        static string NonIdempotentQueueNameGenerator(string destination, string prefix)
+        {
+            return $"{prefix}{destination}";
+        }
+    }
+}

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -245,6 +245,8 @@
         /// </summary>
         public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
         {
+            AssertQueueNameGeneratorIdempotent(queueNameGenerator);
+
             var topicCache = new TopicCache(SnsClient, hostSettings.CoreSettings, eventToTopicsMappings, eventToEventsMappings, topicNameGenerator, topicNamePrefix);
             var infra = new SqsTransportInfrastructure(this, hostSettings, receivers, SqsClient, SnsClient, QueueCache, topicCache, S3, Policies, QueueDelayTime, topicNamePrefix, EnableV1CompatibilityMode, DoNotWrapOutgoingMessages, !externallyManagedSqsClient, !externallyManagedSnsClient);
 
@@ -259,6 +261,19 @@
             }
 
             return infra;
+        }
+
+        static void AssertQueueNameGeneratorIdempotent(Func<string, string, string> generator)
+        {
+            const string prefix = "Prefix";
+            const string destination = "Destination";
+
+            var once = generator(destination, prefix);
+            var twice = generator(once, prefix);
+            if (once != twice)
+            {
+                throw new Exception($"The queue name generator function needs to return the same result when it is applied multiple times (idempotent). Result of applying once is {once} and twice -- {twice}.");
+            }
         }
 
         QueueCache QueueCache =>


### PR DESCRIPTION
Backport of #2321, related to #2314