### PR TITLE
Remove DisableSubscribeBatchingOnStart settings key

### DIFF
--- a/src/NServiceBus.Transport.SQS/Configure/SettingsKeys.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SettingsKeys.cs
@@ -30,7 +30,6 @@
 
         public const string V1CompatibilityMode = Prefix + nameof(V1CompatibilityMode);
         public const string DisableNativePubSub = Prefix + nameof(DisableNativePubSub);
-        public const string DisableSubscribeBatchingOnStart = Prefix + nameof(DisableSubscribeBatchingOnStart);
 
         public const string MessageVisibilityTimeout = Prefix + nameof(MessageVisibilityTimeout);
         public const string SubscriptionsCacheTTL = Prefix + nameof(SubscriptionsCacheTTL);


### PR DESCRIPTION
With v8 the subscription batching setting is no longer required because Core hands overall all subscription metadata in one go. This code was probably refactored but this setting never removed