### PR TITLE
Add AWSSDK.SecurityToken package to support service accounts

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.308.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.115" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.43" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.300.72" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.0" />

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.308.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.115" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.43" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.300.72" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.0" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.308.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.115" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.43" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.300.72" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.0" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="[3.7.305.29, 3.8.0)" />
+    <!-- Required for IAM Roles for Service Accounts even though no API is added -->
+    <PackageReference Include="AWSSDK.SecurityToken" Version="[3.7.300.115, 3.8.0)" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.301.1, 3.8.0)" />
     <PackageReference Include="AWSSDK.SQS" Version="[3.7.300.53, 3.8.0)" />
     <PackageReference Include="BitFaster.Caching" Version="[2.4.1, 3.0.0)" />


### PR DESCRIPTION
Without this dependency, an endpoint will fail with FileNotFoundException if attempting to authenticate as a service account. It can be added explicitly to an endpoint to fix the problem, but this allows the dependency to be included with the transport.