### PR TITLE
Add internal property to disable delay delivery

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
@@ -60,7 +60,8 @@ namespace NServiceBus.Transport.SQS.Tests
                 "",
                 false,
                 disposeSqs,
-                disposeSns);
+                disposeSns,
+                false);
 
             await sut.Shutdown(CancellationToken.None);
 

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -58,6 +58,11 @@
         public string QueueNamePrefix { get; set; }
 
         /// <summary>
+        /// Disable native delayed delivery infrastructure
+        /// </summary>
+        internal bool DisableDelayedDelivery { get; set; } = false;
+
+        /// <summary>
         /// Specifies a lambda function that allows to take control of the queue name generation logic.
         /// This is useful to overcome any limitations imposed by SQS.
         /// </summary>
@@ -248,14 +253,14 @@
             AssertQueueNameGeneratorIdempotent(queueNameGenerator);
 
             var topicCache = new TopicCache(SnsClient, hostSettings.CoreSettings, eventToTopicsMappings, eventToEventsMappings, topicNameGenerator, topicNamePrefix);
-            var infra = new SqsTransportInfrastructure(hostSettings, receivers, SqsClient, SnsClient, QueueCache, topicCache, S3, Policies, QueueDelayTime, topicNamePrefix, DoNotWrapOutgoingMessages, !externallyManagedSqsClient, !externallyManagedSnsClient);
+            var infra = new SqsTransportInfrastructure(hostSettings, receivers, SqsClient, SnsClient, QueueCache, topicCache, S3, Policies, QueueDelayTime, topicNamePrefix, DoNotWrapOutgoingMessages, !externallyManagedSqsClient, !externallyManagedSnsClient, DisableDelayedDelivery);
 
             if (hostSettings.SetupInfrastructure)
             {
                 var queueCreator = new QueueCreator(SqsClient, QueueCache, S3, maxTimeToLive, QueueDelayTime);
 
                 var createQueueTasks = sendingAddresses.Select(x => queueCreator.CreateQueueIfNecessary(x, false, cancellationToken))
-                    .Concat(infra.Receivers.Values.Select(x => queueCreator.CreateQueueIfNecessary(x.ReceiveAddress, true, cancellationToken))).ToArray();
+                    .Concat(infra.Receivers.Values.Select(x => queueCreator.CreateQueueIfNecessary(x.ReceiveAddress, !DisableDelayedDelivery, cancellationToken))).ToArray();
 
                 await Task.WhenAll(createQueueTasks).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
@@ -15,13 +15,14 @@
     {
         public SqsTransportInfrastructure(HostSettings hostSettings, ReceiveSettings[] receiverSettings, IAmazonSQS sqsClient,
             IAmazonSimpleNotificationService snsClient, QueueCache queueCache, TopicCache topicCache, S3Settings s3Settings, PolicySettings policySettings, int queueDelayTimeSeconds, string topicNamePrefix, bool doNotWrapOutgoingMessages,
-            bool shouldDisposeSqsClient, bool shouldDisposeSnsClient)
+            bool shouldDisposeSqsClient, bool shouldDisposeSnsClient, bool disableDelayedDelivery)
         {
             this.sqsClient = sqsClient;
             this.snsClient = snsClient;
             this.queueCache = queueCache;
             this.shouldDisposeSqsClient = shouldDisposeSqsClient;
             this.shouldDisposeSnsClient = shouldDisposeSnsClient;
+            this.disableDelayedDelivery = disableDelayedDelivery;
             coreSettings = hostSettings.CoreSettings;
             s3Client = s3Settings?.S3Client;
             setupInfrastructure = hostSettings.SetupInfrastructure;
@@ -42,7 +43,7 @@
             var receiveAddress = ToTransportAddress(receiveSettings.ReceiveAddress);
             var subManager = new SubscriptionManager(sqsClient, snsClient, receiveAddress, queueCache, topicCache, policySettings, topicNamePrefix, setupInfrastructure);
 
-            return new MessagePump(receiveSettings.Id, receiveAddress, receiveSettings.ErrorQueue, receiveSettings.PurgeOnStartup, sqsClient, queueCache, s3Settings, subManager, queueDelayTimeSeconds, criticalErrorAction, coreSettings, setupInfrastructure);
+            return new MessagePump(receiveSettings.Id, receiveAddress, receiveSettings.ErrorQueue, receiveSettings.PurgeOnStartup, sqsClient, queueCache, s3Settings, subManager, queueDelayTimeSeconds, criticalErrorAction, coreSettings, setupInfrastructure, disableDelayedDelivery);
         }
 
         public override Task Shutdown(CancellationToken cancellationToken = default)
@@ -90,6 +91,7 @@
         readonly bool setupInfrastructure;
         readonly bool shouldDisposeSqsClient;
         readonly bool shouldDisposeSnsClient;
+        readonly bool disableDelayedDelivery;
         readonly bool shouldDisposeS3Client;
     }
 }


### PR DESCRIPTION
This workaround allows ServiceControl to disable delay delivery for non-main message pumps.

This is the same workaround already in use for [SqlServer in ServiceControl](https://github.com/Particular/ServiceControl/blob/56f29e8fe68a51acb770153b7d140473d58c20fc/src/ServiceControl.Transports.SqlServer/SqlServerTransportCustomization.cs#L76-L77).

Property in SQLServer Transport: https://github.com/Particular/NServiceBus.SqlServer/blob/master/src/NServiceBus.Transport.SqlServer/SqlServerTransport.cs#L159
Usage of the property to determine delayed delivery on/off: https://github.com/Particular/NServiceBus.SqlServer/blob/master/src/NServiceBus.Transport.SqlServer/SqlServerTransportInfrastructure.cs#L161
