### PR TITLE
Bump AWS SDks lower range to 3.7.400 to fix an obsolete property

### DIFF
--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.308.4" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.43" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.72" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.308.4" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.115" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.43" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.72" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/src/NServiceBus.Transport.SQS.Tests/DelayedMessagesPumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/DelayedMessagesPumpTests.cs
@@ -127,7 +127,7 @@ namespace NServiceBus.Transport.SQS.Tests
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MaxNumberOfMessages == 10), "MaxNumberOfMessages did not match");
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.QueueUrl == FakeDelayedMessagesFifoQueueUrl), "QueueUrl did not match");
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.WaitTimeSeconds == 20), "WaitTimeSeconds did not match");
-            Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.AttributeNames
+            Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageSystemAttributeNames
                 .SequenceEqual(["MessageDeduplicationId", "SentTimestamp", "ApproximateFirstReceiveTimestamp", "ApproximateReceiveCount"])), "AttributeNames did not match");
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageAttributeNames.SequenceEqual(["All"])), "MessageAttributeNames did not match");
         }

--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -57,7 +57,7 @@ namespace NServiceBus.Transport.SQS.Tests
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MaxNumberOfMessages == 1), "MaxNumberOfMessages did not match");
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.QueueUrl == FakeInputQueueQueueUrl), "QueueUrl did not match");
             Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageAttributeNames.SequenceEqual(["All"])), "MessageAttributeNames did not match");
-            Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.AttributeNames.SequenceEqual(["SentTimestamp"])), "AttributeNames did not match");
+            Assert.IsTrue(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageSystemAttributeNames.SequenceEqual(["SentTimestamp"])), "AttributeNames did not match");
         }
 
         [Test]

--- a/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
+++ b/src/NServiceBus.Transport.SQS.Tests/NServiceBus.Transport.SQS.Tests.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.308.4" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.115" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.43" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.72" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.308.4" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.115" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.43" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.72" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.1" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
@@ -91,7 +91,7 @@ namespace NServiceBus.Transport.SQS
                 MaxNumberOfMessages = 10,
                 QueueUrl = delayedDeliveryQueueUrl,
                 WaitTimeSeconds = 20,
-                AttributeNames = ["MessageDeduplicationId", "SentTimestamp", "ApproximateFirstReceiveTimestamp", "ApproximateReceiveCount"],
+                MessageSystemAttributeNames = ["MessageDeduplicationId", "SentTimestamp", "ApproximateFirstReceiveTimestamp", "ApproximateReceiveCount"],
                 MessageAttributeNames = ["All"]
             };
 

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -121,7 +121,7 @@ namespace NServiceBus.Transport.SQS
                 MaxNumberOfMessages = numberOfMessagesToFetch,
                 QueueUrl = inputQueueUrl,
                 WaitTimeSeconds = 20,
-                AttributeNames = ["SentTimestamp"],
+                MessageSystemAttributeNames = ["SentTimestamp"],
                 MessageAttributeNames = ["All"]
             };
 

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="[3.7.305.29, 3.8.0)" />
+    <PackageReference Include="AWSSDK.S3" Version="[3.7.400, 3.8.0)" />
     <!-- Required for IAM Roles for Service Accounts even though no API is added -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="[3.7.300.115, 3.8.0)" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.301.1, 3.8.0)" />
-    <PackageReference Include="AWSSDK.SQS" Version="[3.7.300.53, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="[3.7.400, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="[3.7.400, 3.8.0)" />
+    <PackageReference Include="AWSSDK.SQS" Version="[3.7.400, 3.8.0)" />
     <PackageReference Include="BitFaster.Caching" Version="[2.4.1, 3.0.0)" />
     <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
   </ItemGroup>


### PR DESCRIPTION
- [x] Test that the change doesn't break wire compatibility with older SDK versions 