### PR TITLE
Flat headers

### DIFF
--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -383,14 +383,13 @@ namespace NServiceBus.Transport.SQS
                             Logger.Debug($"Message with native id {receivedMessage.MessageId} does not contain the required information and will not be treated as an NServiceBus TransportMessage. " +
                                    $"Instead it'll be treated as pure native message.");
 
+                            var headersFromAttributes = receivedMessage.MessageAttributes.ToDictionary(k => k.Key, v => v.Value.StringValue);
+                            headersFromAttributes[Headers.MessageId] = receivedMessage.MessageId;
+
                             transportMessage = new TransportMessage
                             {
                                 Body = receivedMessage.Body,
-                                Headers = new Dictionary<string, string>
-                                {
-                                    // HINT: Message Id is a required field for InnerProcessMessage
-                                    [Headers.MessageId] = receivedMessage.MessageId,
-                                }
+                                Headers = headersFromAttributes
                             };
                         }
                     }

--- a/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
@@ -376,7 +376,20 @@ namespace NServiceBus.Transport.SQS
             if (!wrapOutgoingMessages)
             {
                 (preparedMessage.Body, var headers) = GetMessageBodyAndHeaders(transportOperation.Message);
-                preparedMessage.MessageAttributes[TransportHeaders.Headers] = new MessageAttributeValue { StringValue = headers, DataType = "String" };
+
+                var flatHeaders = transportOperation.Properties.ContainsKey(Experimental.TransportOperationExt.FlatHeadersKey);
+
+                if (flatHeaders)
+                {
+                    foreach (var i in transportOperation.Message.Headers)
+                    {
+                        preparedMessage.MessageAttributes[i.Key] = new MessageAttributeValue { StringValue = i.Value, DataType = "String" };
+                    }
+                }
+                else
+                {
+                    preparedMessage.MessageAttributes[TransportHeaders.Headers] = new MessageAttributeValue { StringValue = headers, DataType = "String" };
+                }
 
                 await PrepareSqsMessageBasedOnBodySize(default).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
@@ -377,7 +377,7 @@ namespace NServiceBus.Transport.SQS
             {
                 (preparedMessage.Body, var headers) = GetMessageBodyAndHeaders(transportOperation.Message);
 
-                var flatHeaders = transportOperation.Properties.ContainsKey(Experimental.TransportOperationExt.FlatHeadersKey);
+                var flatHeaders = transportOperation.Properties.ContainsKey(TransportOperationExt.FlatHeadersKey);
 
                 if (flatHeaders)
                 {

--- a/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
@@ -377,7 +377,7 @@ namespace NServiceBus.Transport.SQS
             {
                 (preparedMessage.Body, var headers) = GetMessageBodyAndHeaders(transportOperation.Message);
 
-                var flatHeaders = transportOperation.Properties.ContainsKey(TransportOperationExt.FlatHeadersKey);
+                var flatHeaders = transportOperation.Properties.ContainsKey(FlatHeadersKey);
 
                 if (flatHeaders)
                 {
@@ -583,5 +583,7 @@ namespace NServiceBus.Transport.SQS
         readonly QueueCache queueCache;
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(MessageDispatcher));
+
+        internal const string FlatHeadersKey = "NServiceBus.Transport.SQS.Internal.FlatHeaders";
     }
 }

--- a/src/NServiceBus.Transport.SQS/MessageDispatcherProperties.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcherProperties.cs
@@ -1,12 +1,9 @@
 #nullable enable
-namespace NServiceBus.Transport.SQS.Experimental;
+namespace NServiceBus.Transport.SQS;
 
-using System;
-
-[Obsolete("This is an experimental setting")]
 public static class TransportOperationExt
 {
-    internal static string FlatHeadersKey = "FlatHeaders";
+    internal static string FlatHeadersKey = "NServiceBus.Transport.SQS.FlatHeaders";
 
     /// <summary>
     /// Unsupported setting to not wrap headers into a single property for sending native messages

--- a/src/NServiceBus.Transport.SQS/MessageDispatcherProperties.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcherProperties.cs
@@ -1,0 +1,18 @@
+#nullable enable
+namespace NServiceBus.Transport.SQS.Experimental;
+
+using System;
+
+[Obsolete("This is an experimental setting")]
+public static class TransportOperationExt
+{
+    internal static string FlatHeadersKey = "FlatHeaders";
+
+    /// <summary>
+    /// Unsupported setting to not wrap headers into a single property for sending native messages
+    /// </summary>
+    public static void UseFlatHeaders(this TransportOperation instance)
+    {
+        instance.Properties[FlatHeadersKey] = bool.TrueString;
+    }
+}

--- a/src/NServiceBus.Transport.SQS/MessageDispatcherProperties.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcherProperties.cs
@@ -1,6 +1,11 @@
 #nullable enable
 namespace NServiceBus.Transport.SQS;
 
+using System;
+
+/// <summary>
+/// Extension methods for <see cref="TransportOperation"/>.
+/// </summary>
 public static class TransportOperationExt
 {
     internal static string FlatHeadersKey = "NServiceBus.Transport.SQS.FlatHeaders";
@@ -10,6 +15,11 @@ public static class TransportOperationExt
     /// </summary>
     public static void UseFlatHeaders(this TransportOperation instance)
     {
+        if (instance == null)
+        {
+            throw new ArgumentNullException(nameof(instance));
+        }
+
         instance.Properties[FlatHeadersKey] = bool.TrueString;
     }
 }

--- a/src/NServiceBus.Transport.SQS/TransportOperationExtensions.cs
+++ b/src/NServiceBus.Transport.SQS/TransportOperationExtensions.cs
@@ -1,15 +1,13 @@
 #nullable enable
-namespace NServiceBus.Transport.SQS;
+namespace NServiceBus.Transport.SQS.Internal;
 
 using System;
 
 /// <summary>
 /// Extension methods for <see cref="TransportOperation"/>.
 /// </summary>
-public static class TransportOperationExt
+public static class TransportOperationExtensions
 {
-    internal static string FlatHeadersKey = "NServiceBus.Transport.SQS.FlatHeaders";
-
     /// <summary>
     /// Unsupported setting to not wrap headers into a single property for sending native messages
     /// </summary>
@@ -20,6 +18,6 @@ public static class TransportOperationExt
             throw new ArgumentNullException(nameof(instance));
         }
 
-        instance.Properties[FlatHeadersKey] = bool.TrueString;
+        instance.Properties[MessageDispatcher.FlatHeadersKey] = bool.TrueString;
     }
 }


### PR DESCRIPTION
NServiceBus serialized all headers into a single native header to workaround the 10 header limit. However, for native integration purposes is can be useful to set the headers so that the message format conforms to the receiver contract.