### PR TITLE
Stop pumps on shutdown 

### DIFF
--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
@@ -46,8 +46,11 @@
             return new MessagePump(receiveSettings.Id, receiveAddress, receiveSettings.ErrorQueue, receiveSettings.PurgeOnStartup, sqsClient, queueCache, s3Settings, subManager, queueDelayTimeSeconds, criticalErrorAction, coreSettings, setupInfrastructure, disableDelayedDelivery);
         }
 
-        public override Task Shutdown(CancellationToken cancellationToken = default)
+        public override async Task Shutdown(CancellationToken cancellationToken = default)
         {
+            await Task.WhenAll(Receivers.Values.Select(pump => pump.StopReceive(cancellationToken)))
+                .ConfigureAwait(false);
+
             if (shouldDisposeSqsClient)
             {
                 sqsClient.Dispose();
@@ -62,8 +65,6 @@
             {
                 s3Client?.Dispose();
             }
-
-            return Task.CompletedTask;
         }
 
         public override string ToTransportAddress(QueueAddress address)

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
@@ -73,12 +73,12 @@
             var queue = new StringBuilder(queueName);
             if (address.Discriminator != null)
             {
-                queue.Append("-" + address.Discriminator);
+                queue.Append($"-{address.Discriminator}");
             }
 
             if (address.Qualifier != null)
             {
-                queue.Append("-" + address.Qualifier);
+                queue.Append($"-{address.Qualifier}");
             }
 
             return queueCache.GetPhysicalQueueName(queue.ToString());

--- a/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/DelayedMessagesPump.cs
@@ -106,7 +106,7 @@ namespace NServiceBus.Transport.SQS
                 return; //already stopped
             }
 
-            tokenSource.Cancel();
+            await tokenSource.CancelAsync().ConfigureAwait(false);
 
             if (pumpTask != null)
             {


### PR DESCRIPTION
This aligns the transport to stop the pumps on transport shutdown and at the same time makes sure the pumps stop method can be called multiple times. 

This is part of addressing some low-hanging fruit to align all transports for the transport seam usage scenarios to make sure pumps are stopped when the transport shuts down. 

I have tried to write a transport test for it to enforce it eventually for all transport but couldn't find a way to do that without introducing flags on the transport interface and using fancy techniques like default members which seams overkill