### PR TITLE
Externally managed SNS/SQS clients were disposed when experimental constructor added in 7.1.0

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
@@ -73,7 +73,7 @@ namespace NServiceBus.Transport.SQS.Tests
         }
 
         [Test]
-        public async Task Should_not_dispose_clients_passed_into_transport_constructor_1()
+        public async Task Should_not_dispose_clients_passed_into_transport_constructor()
         {
             var mockSqsClient = new MockSqsClient();
             var mockSnsClient = new MockSnsClient();
@@ -107,7 +107,7 @@ namespace NServiceBus.Transport.SQS.Tests
         }
 
         [Test]
-        public async Task Should_not_dispose_clients_passed_into_transport_constructor_2()
+        public async Task Should_not_dispose_clients_passed_into_transport_constructor_with_delayed_delivery()
         {
             var mockSqsClient = new MockSqsClient();
             var mockSnsClient = new MockSnsClient();

--- a/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
@@ -73,13 +73,49 @@ namespace NServiceBus.Transport.SQS.Tests
         }
 
         [Test]
-        public async Task Should_not_dispose_clients_passed_into_transport()
+        public async Task Should_not_dispose_clients_passed_into_transport_constructor_1()
         {
             var mockSqsClient = new MockSqsClient();
             var mockSnsClient = new MockSnsClient();
             var mockS3Client = new MockS3Client();
 
             var transport = new SqsTransport(mockSqsClient, mockSnsClient)
+            {
+                S3 = new S3Settings("123", "k", mockS3Client)
+            };
+
+            var hostSettings = new HostSettings(
+                "Test",
+                "Test",
+                new StartupDiagnosticEntries(),
+                (s, ex, cancel) => { },
+                false
+            );
+            var receivers = Array.Empty<ReceiveSettings>();
+            var sendingAddresses = Array.Empty<string>();
+
+            var infra = await transport.Initialize(hostSettings, receivers, sendingAddresses);
+
+            await infra.Shutdown();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(mockSqsClient.DisposeInvoked, Is.False);
+                Assert.That(mockSnsClient.DisposeInvoked, Is.False);
+                Assert.That(mockS3Client.DisposeInvoked, Is.False);
+            });
+        }
+
+        [Test]
+        public async Task Should_not_dispose_clients_passed_into_transport_constructor_2()
+        {
+            var mockSqsClient = new MockSqsClient();
+            var mockSnsClient = new MockSnsClient();
+            var mockS3Client = new MockS3Client();
+
+#pragma warning disable NSBSQSEXP0001
+            var transport = new SqsTransport(mockSqsClient, mockSnsClient, enableDelayedDelivery: false)
+#pragma warning restore NSBSQSEXP0001
             {
                 S3 = new S3Settings("123", "k", mockS3Client)
             };

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -241,17 +241,19 @@
             IAmazonSimpleNotificationService snsClient,
             bool enableDelayedDelivery
         )
-            : this(
-                sqsClient,
-                snsClient,
+            : base(
+                TransportTransactionMode.ReceiveOnly,
+                supportsDelayedDelivery: enableDelayedDelivery,
                 supportsPublishSubscribe: true,
-                enableDelayedDelivery: enableDelayedDelivery
+                supportsTTBR: true
             )
         {
-            this.sqsClient = sqsClient;
-            this.snsClient = snsClient;
+            // Use properties to ensure `externallyManagedSqsClient` is set
+            SqsClient = sqsClient;
+            SnsClient = snsClient;
         }
 
+        // Only invoke when not using external SQS and SNS clients
         internal SqsTransport(
             IAmazonSQS sqsClient,
             IAmazonSimpleNotificationService snsClient,


### PR DESCRIPTION
Externally managed SNS/SQS clients were disposed at shutdown when using new `SqsTransport(IAmazonSQS, IAmazonSimpleNotificationService snsClient, bool)` constructor in version https://github.com/Particular/NServiceBus.AmazonSQS/releases/tag/7.1.0