### PR TITLE
Revert "Fix failing tests"

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/Sending/When_using_large_message_with_customer_provided_aes.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/Sending/When_using_large_message_with_customer_provided_aes.cs
@@ -39,7 +39,7 @@ namespace NServiceBus.AcceptanceTests.Sending
 
             Assert.Multiple(() =>
             {
-                Assert.That(getObjectResponse.ServerSideEncryptionCustomerMethod.Value, Is.EqualTo(ServerSideEncryptionCustomerMethod.AES256.Value));
+                Assert.That(getObjectResponse.ServerSideEncryptionCustomerMethod, Is.EqualTo(ServerSideEncryptionCustomerMethod.AES256));
                 Assert.That(getObjectResponse.ServerSideEncryptionMethod, Is.Null);
             });
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/Sending/When_using_large_message_with_serverside_aes.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/Sending/When_using_large_message_with_serverside_aes.cs
@@ -30,8 +30,8 @@ namespace NServiceBus.AcceptanceTests.Sending
 
             Assert.Multiple(() =>
             {
-                Assert.That(getObjectResponse.ServerSideEncryptionMethod.Value, Is.EqualTo(ServerSideEncryptionMethod.AES256.Value));
-                Assert.That(getObjectResponse.ServerSideEncryptionCustomerMethod.Value, Is.EqualTo(ServerSideEncryptionCustomerMethod.None.Value));
+                Assert.That(getObjectResponse.ServerSideEncryptionMethod, Is.EqualTo(ServerSideEncryptionMethod.AES256));
+                Assert.That(getObjectResponse.ServerSideEncryptionCustomerMethod, Is.EqualTo(ServerSideEncryptionCustomerMethod.None));
             });
         }
 


### PR DESCRIPTION
This reverts commit faf1167fd2b15a6fbe8e548d3fb6efa891e9df5f.

Similarly to https://github.com/Particular/NServiceBus.Persistence.DynamoDB/pull/757, with the release of NUnit 4.3.1 (https://github.com/Particular/NServiceBus.AmazonSQS/pull/2674) the previously applied fix can be reverted.