### PR TITLE
Improve the poison message deletion handling to reduce the chance of duplicates

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -106,6 +106,65 @@ namespace NServiceBus.Transport.SQS.Tests
             Assert.That(mockSqsClient.DeleteMessageRequestsSent.Single().receiptHandle, Is.EqualTo(expectedReceiptHandle));
         }
 
+        static IEnumerable<object[]> PoisonMessageExceptions() =>
+        [
+            [new Exception()],
+            [new ReceiptHandleIsInvalidException("Ooops")]
+        ];
+
+        [Theory]
+        [TestCaseSource(nameof(PoisonMessageExceptions))]
+        public async Task Poison_messages_failed_to_be_deleted_are_deleted_on_next_receive_without_processing(Exception exception)
+        {
+            var nativeMessageId = Guid.NewGuid().ToString();
+            var messageId = Guid.NewGuid().ToString();
+            var expectedFirstReceiptHandle = "receipt-handle-1";
+            var expectedSecondReceiptHandle = "receipt-handle-2";
+
+            var processed = false;
+            await SetupInitializedPump(onMessage: (ctx, ct) =>
+            {
+                processed = true;
+                return Task.FromResult(0);
+            });
+
+            var deleteRequest = mockSqsClient.DeleteMessageRequestResponse;
+            mockSqsClient.DeleteMessageRequestResponse = request => throw exception;
+
+            var message = new Message
+            {
+                ReceiptHandle = expectedFirstReceiptHandle,
+                MessageId = nativeMessageId,
+                MessageAttributes = new Dictionary<string, MessageAttributeValue>
+                {
+                    {Headers.MessageId, new MessageAttributeValue {StringValue = messageId}},
+                },
+                Body = null //poison message
+            };
+
+            // First receive attempt
+            await pump.ProcessMessage(message, CancellationToken.None).ConfigureAwait(false);
+
+            // Restore the previous behavior
+            mockSqsClient.DeleteMessageRequestResponse = deleteRequest;
+            // Second receive attempt of the same message that has already been moved to the error queue
+            // but not deleted from the input queue. It will be received with a new receipt handle.
+            message.ReceiptHandle = expectedSecondReceiptHandle;
+            await pump.ProcessMessage(message, CancellationToken.None).ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(processed, Is.False);
+                Assert.That(mockSqsClient.RequestsSent, Has.Count.EqualTo(1), "The message should not be attempted to be sent multiple times to the error queue.");
+                Assert.That(mockSqsClient.DeleteMessageRequestsSent, Has.Count.EqualTo(2));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(mockSqsClient.DeleteMessageRequestsSent[0].receiptHandle, Is.EqualTo(expectedFirstReceiptHandle));
+                Assert.That(mockSqsClient.DeleteMessageRequestsSent[1].receiptHandle, Is.EqualTo(expectedSecondReceiptHandle));
+            });
+        }
+
         [Test]
         public async Task Expired_messages_are_deleted_without_processing()
         {


### PR DESCRIPTION
This pull request includes changes to improve the handling of poison messages in the SQS transport. The changes primarily focus on ensuring that poison messages, which fail to be deleted, are retried and then immediately attempted to be deleted to prevent unnecessary duplicates.