### PR TITLE
Use "ApproximateReceiveCount" attribute to compute the number of immediate processing failures for ErrorContext

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -160,8 +160,8 @@ namespace NServiceBus.Transport.SQS.Tests
             });
             Assert.Multiple(() =>
             {
-                Assert.That(mockSqsClient.DeleteMessageRequestsSent[0].receiptHandle, Is.EqualTo(expectedFirstReceiptHandle));
-                Assert.That(mockSqsClient.DeleteMessageRequestsSent[1].receiptHandle, Is.EqualTo(expectedSecondReceiptHandle));
+                Assert.That(mockSqsClient.DeleteMessageRequestsSent.ElementAt(0).receiptHandle, Is.EqualTo(expectedFirstReceiptHandle));
+                Assert.That(mockSqsClient.DeleteMessageRequestsSent.ElementAt(1).receiptHandle, Is.EqualTo(expectedSecondReceiptHandle));
             });
         }
 

--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -66,7 +66,7 @@ namespace NServiceBus.Transport.SQS.Tests
                 Assert.That(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MaxNumberOfMessages == 1), Is.True, "MaxNumberOfMessages did not match");
                 Assert.That(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.QueueUrl == FakeInputQueueQueueUrl), Is.True, "QueueUrl did not match");
                 Assert.That(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageAttributeNames.SequenceEqual(["All"])), Is.True, "MessageAttributeNames did not match");
-                Assert.That(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageSystemAttributeNames.SequenceEqual(["SentTimestamp"])), Is.True, "AttributeNames did not match");
+                Assert.That(mockSqsClient.ReceiveMessagesRequestsSent.All(r => r.MessageSystemAttributeNames.SequenceEqual(["ApproximateReceiveCount", "SentTimestamp"])), Is.True, "AttributeNames did not match");
             });
         }
 

--- a/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transport.SQS.Tests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
     using System.Threading;
@@ -12,13 +13,13 @@
 
     public class MockS3Client : IAmazonS3
     {
-        public List<PutObjectRequest> PutObjectRequestsSent { get; } = [];
+        public ConcurrentQueue<PutObjectRequest> PutObjectRequestsSent { get; } = [];
 
         public Func<PutObjectRequest, PutObjectResponse> PutObjectRequestResponse = req => new PutObjectResponse();
 
         public Task<PutObjectResponse> PutObjectAsync(PutObjectRequest request, CancellationToken cancellationToken = new CancellationToken())
         {
-            PutObjectRequestsSent.Add(request);
+            PutObjectRequestsSent.Enqueue(request);
             return Task.FromResult(PutObjectRequestResponse(request));
         }
 

--- a/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus.Transport.SQS.Tests;
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,20 +15,20 @@ using Endpoint = Amazon.Runtime.Endpoints.Endpoint;
 
 class MockSnsClient : IAmazonSimpleNotificationService
 {
-    public List<string> UnsubscribeRequests = [];
+    public ConcurrentQueue<string> UnsubscribeRequests = [];
 
     public Task<UnsubscribeResponse> UnsubscribeAsync(string subscriptionArn, CancellationToken cancellationToken = new CancellationToken())
     {
-        UnsubscribeRequests.Add(subscriptionArn);
+        UnsubscribeRequests.Enqueue(subscriptionArn);
         return Task.FromResult(new UnsubscribeResponse());
     }
 
     public Func<string, Topic> FindTopicAsyncResponse { get; set; } = topic => new Topic { TopicArn = $"arn:aws:sns:us-west-2:123456789012:{topic}" };
-    public List<string> FindTopicRequests { get; } = [];
+    public ConcurrentQueue<string> FindTopicRequests { get; } = [];
 
     public Task<Topic> FindTopicAsync(string topicName)
     {
-        FindTopicRequests.Add(topicName);
+        FindTopicRequests.Enqueue(topicName);
         return Task.FromResult(FindTopicAsyncResponse(topicName));
     }
 
@@ -36,19 +37,19 @@ class MockSnsClient : IAmazonSimpleNotificationService
         TopicArn = $"arn:aws:sns:us-west-2:123456789012:{topic}"
     };
 
-    public List<string> CreateTopicRequests { get; } = [];
+    public ConcurrentQueue<string> CreateTopicRequests { get; } = [];
 
     public Task<CreateTopicResponse> CreateTopicAsync(string name, CancellationToken cancellationToken = new CancellationToken())
     {
-        CreateTopicRequests.Add(name);
+        CreateTopicRequests.Enqueue(name);
         return Task.FromResult(CreateTopicResponse(name));
     }
 
-    public List<PublishRequest> PublishedEvents { get; } = [];
+    public ConcurrentQueue<PublishRequest> PublishedEvents { get; } = [];
 
     public Task<PublishResponse> PublishAsync(PublishRequest request, CancellationToken cancellationToken = new CancellationToken())
     {
-        PublishedEvents.Add(request);
+        PublishedEvents.Enqueue(request);
         return Task.FromResult(new PublishResponse());
     }
 
@@ -57,31 +58,31 @@ class MockSnsClient : IAmazonSimpleNotificationService
         Subscriptions = [],
     };
 
-    public List<string> ListSubscriptionsByTopicRequests { get; } = [];
+    public ConcurrentQueue<string> ListSubscriptionsByTopicRequests { get; } = [];
 
     public Task<ListSubscriptionsByTopicResponse> ListSubscriptionsByTopicAsync(string topicArn, string nextToken, CancellationToken cancellationToken = new CancellationToken())
     {
-        ListSubscriptionsByTopicRequests.Add(topicArn);
+        ListSubscriptionsByTopicRequests.Enqueue(topicArn);
         return Task.FromResult(ListSubscriptionsByTopicResponse(topicArn));
     }
 
-    public List<SubscribeRequest> SubscribeRequestsSent = [];
+    public ConcurrentQueue<SubscribeRequest> SubscribeRequestsSent = [];
 
     public Func<SubscribeRequest, SubscribeResponse> SubscribeResponse = req => new SubscribeResponse { SubscriptionArn = "arn:fakeQueue" };
 
     public Task<SubscribeResponse> SubscribeAsync(SubscribeRequest request, CancellationToken cancellationToken = new CancellationToken())
     {
-        SubscribeRequestsSent.Add(request);
+        SubscribeRequestsSent.Enqueue(request);
         return Task.FromResult(SubscribeResponse(request));
     }
 
-    public List<PublishBatchRequest> BatchRequestsPublished { get; } = [];
+    public ConcurrentQueue<PublishBatchRequest> BatchRequestsPublished { get; } = [];
 
     public Func<PublishBatchRequest, PublishBatchResponse> BatchRequestResponse = req => new PublishBatchResponse();
 
     public Task<PublishBatchResponse> PublishBatchAsync(PublishBatchRequest request, CancellationToken cancellationToken = default)
     {
-        BatchRequestsPublished.Add(request);
+        BatchRequestsPublished.Enqueue(request);
         return Task.FromResult(BatchRequestResponse(request));
     }
 

--- a/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
@@ -200,7 +200,7 @@ namespace NServiceBus.Transport.SQS.Tests
             await manager.SubscribeAll(new[] { new MessageMetadata(eventType) }, null);
 
             Assert.That(snsClient.SubscribeRequestsSent, Has.Count.EqualTo(1));
-            var subscribeRequest = snsClient.SubscribeRequestsSent[0];
+            var subscribeRequest = snsClient.SubscribeRequestsSent.ElementAt(0);
             Assert.Multiple(() =>
             {
                 Assert.That(subscribeRequest.Endpoint, Is.EqualTo("arn:fakeQueue"));


### PR DESCRIPTION
Closes #2163 

This PR improves the reliability of receive count tracking in the Amazon SQS transport by combining the existing local LRU cache with the service-provided `ApproximateReceiveCount`.  
Rather than replacing the local cache or relying solely on the potentially unreliable service count, we now take the **maximum** of the two values.

### Rationale

- The current implementation tracks receive counts per message using an endpoint-level LRU cache. However, this is:
  - **Flaky in scale-out scenarios** (multiple endpoints don't share the cache).
  - **Unreliable on endpoint restarts** (cache is wiped).
- AWS `ApproximateReceiveCount` is also not always accurate, and can **under-report** in certain cases. See:
  - https://zaccharles.medium.com/i-actually-thought-you-were-going-to-say-approximatereceivecount-when-i-asked-how-youd-keep-track-282e8f51af17
- By taking `Max(LRU Cache, ApproximateReceiveCount)`:
  - We hedge against both under-reporting by AWS and cache loss during endpoint restarts.
  - We improve reliability without blindly trusting either source.

### Edge Case Considered

An unusual edge case was considered:
- A message is received once and tracked locally.
- Then it's processed via another competing consumer.
- The service-provided receive count increases, but the local cache remains lower.
- Using the max value ensures we reflect the higher count and prevent regressions.

### Trade-offs

- ✅ **Improved accuracy** without a major rework.
- ✅ **Safe fallback** behavior in edge cases.
- ⚠️ Still requires maintaining the LRU cache (storage pressure, eviction policies, GC implications) but those are already existing design restrictions today.

### Additional context

Discussed with @mauroservienti and we concluded, adding a test might just lead to another flaky test. An acceptance test would have to start an endpoint, handle the message once, stop the scenario, run another scenario and then try to assert that the number of retries is an exact match. It is challenging to abort an acceptance test scenarios in that exact manner.

I have also looked at a transport test, but unfortunately the transport test infrastructure is so rigid that it doesn't really allow you to properly restart pumps and wipe out the previous state. It also has built in assumptions around extracting the stack frame on the `StartPump`. `StartPump` fails if it is not the first await statement in a test, and restarting the pump would require to call `StartPump` multiple times. 

This PR also includes a change to the MockClients that changes the underlying collection types to be concurrency safe because we got flaky tests due to the same list elements being overwritten concurrently

