### PR TITLE
Allow users to disable unrestricted delayed delivery

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/APIApprovals.cs
@@ -13,7 +13,7 @@
         {
             var publicApi = typeof(SqsTransport).Assembly.GeneratePublicApi(new ApiGeneratorOptions
             {
-                ExcludeAttributes = new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" }
+                ExcludeAttributes = ["System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute"]
             });
             Approver.Verify(publicApi);
         }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
@@ -73,7 +73,6 @@ namespace NServiceBus
     {
         public SqsTransport() { }
         public SqsTransport(Amazon.SQS.IAmazonSQS sqsClient, Amazon.SimpleNotificationService.IAmazonSimpleNotificationService snsClient) { }
-        [System.Diagnostics.CodeAnalysis.Experimental("NSBSQSEXP0001")]
         public SqsTransport(Amazon.SQS.IAmazonSQS sqsClient, Amazon.SimpleNotificationService.IAmazonSimpleNotificationService snsClient, bool enableDelayedDelivery) { }
         public bool DoNotWrapOutgoingMessages { get; set; }
         [System.Obsolete("The SQS transport no longer supports 1.x compatibility mode. Will be removed in v" +

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
@@ -71,9 +71,8 @@ namespace NServiceBus
     }
     public class SqsTransport : NServiceBus.Transport.TransportDefinition
     {
-        public SqsTransport() { }
-        public SqsTransport(Amazon.SQS.IAmazonSQS sqsClient, Amazon.SimpleNotificationService.IAmazonSimpleNotificationService snsClient) { }
-        public SqsTransport(Amazon.SQS.IAmazonSQS sqsClient, Amazon.SimpleNotificationService.IAmazonSimpleNotificationService snsClient, bool enableDelayedDelivery) { }
+        public SqsTransport(bool disableUnrestrictedDelayedDelivery = false) { }
+        public SqsTransport(Amazon.SQS.IAmazonSQS sqsClient, Amazon.SimpleNotificationService.IAmazonSimpleNotificationService snsClient, bool disableUnrestrictedDelayedDelivery = false) { }
         public bool DoNotWrapOutgoingMessages { get; set; }
         [System.Obsolete("The SQS transport no longer supports 1.x compatibility mode. Will be removed in v" +
             "ersion 8.0.0.", true)]

--- a/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.Transport.SQS.Tests
 
             var sut = new SqsTransportInfrastructure(
                 hostSettings,
-                Array.Empty<ReceiveSettings>(),
+                [],
                 mockSqsClient,
                 mockSnsClient,
                 queueCache,
@@ -107,16 +107,16 @@ namespace NServiceBus.Transport.SQS.Tests
             });
         }
 
-        [Test]
-        public async Task Should_not_dispose_clients_passed_into_transport_constructor_with_delayed_delivery()
+        [Theory]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_not_dispose_clients_passed_into_transport_constructor_accepting_delayed_delivery_settings(bool enableDelayedDelivery)
         {
             var mockSqsClient = new MockSqsClient();
             var mockSnsClient = new MockSnsClient();
             var mockS3Client = new MockS3Client();
 
-#pragma warning disable NSBSQSEXP0001
-            var transport = new SqsTransport(mockSqsClient, mockSnsClient, enableDelayedDelivery: false)
-#pragma warning restore NSBSQSEXP0001
+            var transport = new SqsTransport(mockSqsClient, mockSnsClient, enableDelayedDelivery: true)
             {
                 S3 = new S3Settings("123", "k", mockS3Client)
             };

--- a/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SdkClientsDisposeTests.cs
@@ -110,13 +110,13 @@ namespace NServiceBus.Transport.SQS.Tests
         [Theory]
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Should_not_dispose_clients_passed_into_transport_constructor_accepting_delayed_delivery_settings(bool enableDelayedDelivery)
+        public async Task Should_not_dispose_clients_passed_into_transport_constructor_accepting_delayed_delivery_settings(bool disableUnrestrictedDelayedDelivery)
         {
             var mockSqsClient = new MockSqsClient();
             var mockSnsClient = new MockSnsClient();
             var mockS3Client = new MockS3Client();
 
-            var transport = new SqsTransport(mockSqsClient, mockSnsClient, enableDelayedDelivery: true)
+            var transport = new SqsTransport(mockSqsClient, mockSnsClient, disableUnrestrictedDelayedDelivery: disableUnrestrictedDelayedDelivery)
             {
                 S3 = new S3Settings("123", "k", mockS3Client)
             };

--- a/src/NServiceBus.Transport.SQS/Configure/DiagnosticDescriptors.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/DiagnosticDescriptors.cs
@@ -1,5 +1,9 @@
 static class DiagnosticDescriptors
 {
     // https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/choosing-diagnostic-ids
+    // This diagnostic ID was introduced in 7.1 and was used to mark a constructor overload as experimental.
+    // Subsequent releases made the constructor overload officially supported and removed the experimental attribute.
+    // Given this ID was already used it shouldn't be reused for a different diagnostic since that might constitute
+    // a source breaking change.
     public const string ExperimentalDisableDelayedDelivery = "NSBSQSEXP0001";
 }

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -230,7 +229,6 @@
         /// <summary>
         /// Creates a new instance of the SQS transport definition.
         /// </summary>
-        [Experimental(DiagnosticDescriptors.ExperimentalDisableDelayedDelivery)]
         public SqsTransport(
             IAmazonSQS sqsClient,
             IAmazonSimpleNotificationService snsClient,

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -211,8 +211,9 @@
         /// <summary>
         /// Creates a new instance of the SQS transport definition.
         /// </summary>
-        public SqsTransport(IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient)
-            : this(sqsClient, snsClient, externallyManaged: true)
+        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c> the unrestricted delayed delivery will be disabled which means when trying to send delayed messages for longer than 15 minutes the transport will throw an exception.</paramref>
+        public SqsTransport(IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient, bool disableUnrestrictedDelayedDelivery = false)
+            : this(sqsClient, snsClient, externallyManaged: true, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
         {
         }
 
@@ -221,28 +222,10 @@
         ///
         /// Uses SQS and SNS clients created using a default constructor (based on the the settings from the environment)
         /// </summary>
-        public SqsTransport()
-            : this(DefaultClientFactories.SqsFactory(), DefaultClientFactories.SnsFactory(), externallyManaged: false)
+        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c> the unrestricted delayed delivery will be disabled which means when trying to send delayed messages for longer than 15 minutes the transport will throw an exception.</paramref>
+        public SqsTransport(bool disableUnrestrictedDelayedDelivery = false)
+            : this(DefaultClientFactories.SqsFactory(), DefaultClientFactories.SnsFactory(), externallyManaged: false, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
         {
-        }
-
-        /// <summary>
-        /// Creates a new instance of the SQS transport definition.
-        /// </summary>
-        public SqsTransport(
-            IAmazonSQS sqsClient,
-            IAmazonSimpleNotificationService snsClient,
-            bool enableDelayedDelivery
-        )
-            : base(
-                TransportTransactionMode.ReceiveOnly,
-                supportsDelayedDelivery: enableDelayedDelivery,
-                supportsPublishSubscribe: true,
-                supportsTTBR: true
-            )
-        {
-            SetupSqsClient(sqsClient, true);
-            SetupSnsClient(snsClient, true);
         }
 
         // Only invoke when not using external SQS and SNS clients

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -211,7 +211,7 @@
         /// <summary>
         /// Creates a new instance of the SQS transport definition.
         /// </summary>
-        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c> the unrestricted delayed delivery will be disabled which means when trying to send delayed messages for longer than 15 minutes the transport will throw an exception.</paramref>
+        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed 15 minutes.</paramref>.
         public SqsTransport(IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient, bool disableUnrestrictedDelayedDelivery = false)
             : this(sqsClient, snsClient, externallyManaged: true, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
         {
@@ -222,7 +222,7 @@
         ///
         /// Uses SQS and SNS clients created using a default constructor (based on the the settings from the environment)
         /// </summary>
-        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c> the unrestricted delayed delivery will be disabled which means when trying to send delayed messages for longer than 15 minutes the transport will throw an exception.</paramref>
+        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed 15 minutes.</paramref>.
         public SqsTransport(bool disableUnrestrictedDelayedDelivery = false)
             : this(DefaultClientFactories.SqsFactory(), DefaultClientFactories.SnsFactory(), externallyManaged: false, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
         {

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -211,7 +211,7 @@
         /// <summary>
         /// Creates a new instance of the SQS transport definition.
         /// </summary>
-        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed 15 minutes.</paramref>.
+        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed the <see cref="QueueDelayTime" /> value, which by default is 15 minutes.</paramref>.
         public SqsTransport(IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient, bool disableUnrestrictedDelayedDelivery = false)
             : this(sqsClient, snsClient, externallyManaged: true, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
         {
@@ -222,7 +222,7 @@
         ///
         /// Uses SQS and SNS clients created using a default constructor (based on the the settings from the environment)
         /// </summary>
-        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed 15 minutes.</paramref>.
+        /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed the <see cref="QueueDelayTime" /> value, which by default is 15 minutes.</paramref>.
         public SqsTransport(bool disableUnrestrictedDelayedDelivery = false)
             : this(DefaultClientFactories.SqsFactory(), DefaultClientFactories.SnsFactory(), externallyManaged: false, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
         {


### PR DESCRIPTION
Closes https://github.com/Particular/NServiceBus.AmazonSQS/issues/2161 

It appears that adding optional parameters can be a binary breaking change in some scenarios, but it is not a source breaking change. We considered the drop-in replacement of the transport a non-starter and decided to go with an optional parameter on the existing constructors.