### PR TITLE
Propagate native headers to NServiceBus headers

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/Batching/When_batching_multiple_outgoing_small_events.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/Batching/When_batching_multiple_outgoing_small_events.cs
@@ -159,7 +159,7 @@ namespace NServiceBus.AcceptanceTests.Batching
                 public Task Handle(MyEvent messageWithLargePayload, IMessageHandlerContext context)
                 {
                     testContext.MessageIdsReceived.Add(context.MessageId);
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
 
                 readonly Context testContext;

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/Batching/When_batching_multiple_outgoing_small_messages.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/Batching/When_batching_multiple_outgoing_small_messages.cs
@@ -174,7 +174,7 @@ namespace NServiceBus.AcceptanceTests.Batching
                 public Task Handle(MyMessage messageWithLargePayload, IMessageHandlerContext context)
                 {
                     testContext.MessageIdsReceived.Add(context.MessageId);
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_Sending_when_receiver_not_properly_configured.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_Sending_when_receiver_not_properly_configured.cs
@@ -117,7 +117,7 @@
                     testContext.Payload = message.Payload;
                     testContext.ReceivedAt = DateTime.UtcNow;
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_Sending_when_sender_and_receiver_are_properly_configured.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_Sending_when_sender_and_receiver_are_properly_configured.cs
@@ -118,7 +118,7 @@
                     testContext.Payload = message.Payload;
                     testContext.ReceivedAt = DateTime.UtcNow;
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_Sending_when_sender_not_properly_configured.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_Sending_when_sender_not_properly_configured.cs
@@ -86,7 +86,7 @@
                     testContext.Payload = message.Payload;
                     testContext.ReceivedAt = DateTime.UtcNow;
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_when_configured_with_queue_delay_that_requires_multiple_cycles.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/DelayedDelivery/SendOnly_when_configured_with_queue_delay_that_requires_multiple_cycles.cs
@@ -88,7 +88,7 @@
                     testContext.Payload = message.Payload;
                     testContext.ReceivedAt = DateTime.UtcNow;
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -26,7 +26,7 @@
                 {
                     ctx.EventASubscribed = true;
                     ctx.EventBSubscribed = true;
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }))
                 .Done(c => c.GotEventA && c.GotEventB)
                 .Run(TimeSpan.FromSeconds(20));
@@ -73,11 +73,11 @@
                 {
                     if (@event.ContextId != testContext.Id)
                     {
-                        return Task.FromResult(0);
+                        return Task.CompletedTask;
                     }
                     testContext.GotEventA = true;
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
 
                 Context testContext;
@@ -94,12 +94,12 @@
                 {
                     if (@event.ContextId != testContext.Id)
                     {
-                        return Task.FromResult(0);
+                        return Task.CompletedTask;
                     }
 
                     testContext.GotEventB = true;
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 }
 
                 Context testContext;

--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -356,6 +356,7 @@ namespace NServiceBus.Transport.SQS.Tests
             Assert.That(mockSqsClient.ChangeMessageVisibilityRequestsSent, Has.Count.EqualTo(1));
         }
 
+        [Test]
         public async Task Custom_native_headers_are_propagated_to_transport_message_headers()
         {
             var nativeMessageId = Guid.NewGuid().ToString();

--- a/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/InputQueuePumpTests.cs
@@ -45,7 +45,7 @@ namespace NServiceBus.Transport.SQS.Tests
         {
             await pump.Initialize(
                 new PushRuntimeSettings(1),
-                onMessage ?? ((ctx, ct) => Task.FromResult(0)),
+                onMessage ?? ((ctx, ct) => Task.CompletedTask),
                 (ctx, ct) => Task.FromResult(ErrorHandleResult.Handled));
         }
 
@@ -88,7 +88,7 @@ namespace NServiceBus.Transport.SQS.Tests
             await SetupInitializedPump(onMessage: (ctx, ct) =>
             {
                 processed = true;
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             var message = new Message
@@ -133,7 +133,7 @@ namespace NServiceBus.Transport.SQS.Tests
             await SetupInitializedPump(onMessage: (ctx, ct) =>
             {
                 processed = true;
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             var deleteRequest = mockSqsClient.DeleteMessageRequestResponse;
@@ -185,7 +185,7 @@ namespace NServiceBus.Transport.SQS.Tests
             await SetupInitializedPump(onMessage: (ctx, ct) =>
             {
                 processed = true;
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             var json = JsonSerializer.Serialize(new TransportMessage
@@ -234,7 +234,7 @@ namespace NServiceBus.Transport.SQS.Tests
             await SetupInitializedPump(onMessage: (ctx, ct) =>
             {
                 processed = true;
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             var json = JsonSerializer.Serialize(new TransportMessage
@@ -368,7 +368,7 @@ namespace NServiceBus.Transport.SQS.Tests
             await SetupInitializedPump(onMessage: (ctx, ct) =>
             {
                 transportMessageHeaderValue = ctx.Headers[customHeaderKey];
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             var message = new Message

--- a/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
@@ -132,7 +132,7 @@
             {
                 attributeRequestsQueue.Enqueue(attributes);
             }
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public void EnableGetAttributeReturnsWhatWasSet()

--- a/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SubscriptionManagerTests.cs
@@ -489,7 +489,7 @@ namespace NServiceBus.Transport.SQS.Tests
             protected override Task Delay(int millisecondsDelay, CancellationToken cancellationToken = default)
             {
                 Delays.Add(millisecondsDelay);
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -442,6 +442,7 @@ namespace NServiceBus.Transport.SQS
         {
             foreach (var receivedMessageMessageAttribute in receivedMessage.MessageAttributes)
             {
+                // TODO is there a better way to achieve the same result? This seems fragile
                 if (TransportHeaders.AllTransportHeaders.Contains(receivedMessageMessageAttribute.Key) || receivedMessageMessageAttribute.Key == Headers.MessageId)
                 {
                     continue;

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -433,7 +433,21 @@ namespace NServiceBus.Transport.SQS
             }
             // HINT: Message Id is the only required header
             transportMessage.Headers.TryAdd(Headers.MessageId, messageIdOverride);
+            AddCustomNativeHeadersToNServiceBusHeaders(receivedMessage, transportMessage);
+
             return transportMessage;
+        }
+
+        static void AddCustomNativeHeadersToNServiceBusHeaders(Message receivedMessage, TransportMessage transportMessage)
+        {
+            foreach (var receivedMessageMessageAttribute in receivedMessage.MessageAttributes)
+            {
+                if (TransportHeaders.AllTransportHeaders.Contains(receivedMessageMessageAttribute.Key) || receivedMessageMessageAttribute.Key == Headers.MessageId)
+                {
+                    continue;
+                }
+                _ = transportMessage.Headers.TryAdd(receivedMessageMessageAttribute.Key, receivedMessageMessageAttribute.Value?.StringValue ?? string.Empty);
+            }
         }
 
         static bool CouldBeNativeMessage(TransportMessage msg)

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -443,7 +443,7 @@ namespace NServiceBus.Transport.SQS
             foreach (var receivedMessageMessageAttribute in receivedMessage.MessageAttributes)
             {
                 // TODO is there a better way to achieve the same result? This seems fragile
-                if (TransportHeaders.AllTransportHeaders.Contains(receivedMessageMessageAttribute.Key) || receivedMessageMessageAttribute.Key == Headers.MessageId)
+                if (TransportHeaders.AllTransportHeaders.Contains(receivedMessageMessageAttribute.Key))
                 {
                     continue;
                 }

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -442,8 +442,7 @@ namespace NServiceBus.Transport.SQS
         {
             foreach (var receivedMessageMessageAttribute in receivedMessage.MessageAttributes)
             {
-                // TODO is there a better way to achieve the same result? This seems fragile
-                if (TransportHeaders.AllTransportHeaders.Contains(receivedMessageMessageAttribute.Key))
+                if (TransportHeaders.NativeMessageAttributesNotCopiedToNServiceBusHeaders.Contains(receivedMessageMessageAttribute.Key))
                 {
                     continue;
                 }

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -447,7 +447,7 @@ namespace NServiceBus.Transport.SQS
                 {
                     continue;
                 }
-                _ = transportMessage.Headers.TryAdd(receivedMessageMessageAttribute.Key, receivedMessageMessageAttribute.Value?.StringValue ?? string.Empty);
+                transportMessage.Headers[receivedMessageMessageAttribute.Key] = receivedMessageMessageAttribute.Value?.StringValue ?? string.Empty;
             }
         }
 

--- a/src/NServiceBus.Transport.SQS/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/InputQueuePump.cs
@@ -442,7 +442,9 @@ namespace NServiceBus.Transport.SQS
         {
             foreach (var receivedMessageMessageAttribute in receivedMessage.MessageAttributes)
             {
-                if (TransportHeaders.NativeMessageAttributesNotCopiedToNServiceBusHeaders.Contains(receivedMessageMessageAttribute.Key))
+                // The code doesn't allow overriding the message ID at this point because
+                // message id has its own complex set of rules handled earlier in the process 
+                if (TransportHeaders.NativeMessageAttributesNotCopiedToNServiceBusHeaders.Contains(receivedMessageMessageAttribute.Key) || receivedMessageMessageAttribute.Key == Headers.MessageId)
                 {
                     continue;
                 }

--- a/src/NServiceBus.Transport.SQS/TransportHeaders.cs
+++ b/src/NServiceBus.Transport.SQS/TransportHeaders.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Transport.SQS
 {
+    using System.Collections.Generic;
+
     static class TransportHeaders
     {
         const string Prefix = "NServiceBus.AmazonSQS.";
@@ -8,5 +10,6 @@
         public const string Headers = Prefix + nameof(Headers);
         public const string S3BodyKey = "S3BodyKey";
         public const string MessageTypeFullName = "MessageTypeFullName";
+        public static HashSet<string> AllTransportHeaders = [TimeToBeReceived, DelaySeconds, Headers, S3BodyKey, MessageTypeFullName];
     }
 }

--- a/src/NServiceBus.Transport.SQS/TransportHeaders.cs
+++ b/src/NServiceBus.Transport.SQS/TransportHeaders.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport.SQS
 {
+    using System.Collections.Frozen;
     using System.Collections.Generic;
 
     static class TransportHeaders
@@ -10,6 +11,11 @@
         public const string Headers = Prefix + nameof(Headers);
         public const string S3BodyKey = "S3BodyKey";
         public const string MessageTypeFullName = "MessageTypeFullName";
-        public static HashSet<string> AllTransportHeaders = [TimeToBeReceived, DelaySeconds, Headers, S3BodyKey, MessageTypeFullName];
+
+        // The following set represents the list of native message attributes that will
+        // not be copied to NServiceBus headers. When adding a new header to this class
+        // consider if that needs to be propagated to NServiceBus headers, if not, add it
+        // to this frozen set.
+        public static FrozenSet<string> NativeMessageAttributesNotCopiedToNServiceBusHeaders = new HashSet<string>([TimeToBeReceived, DelaySeconds, Headers, S3BodyKey, MessageTypeFullName]).ToFrozenSet();
     }
 }

--- a/src/NServiceBus.Transport.SQS/TransportHeaders.cs
+++ b/src/NServiceBus.Transport.SQS/TransportHeaders.cs
@@ -16,6 +16,6 @@
         // not be copied to NServiceBus headers. When adding a new header to this class
         // consider if that needs to be propagated to NServiceBus headers, if not, add it
         // to this frozen set.
-        public static FrozenSet<string> NativeMessageAttributesNotCopiedToNServiceBusHeaders = new HashSet<string>([TimeToBeReceived, DelaySeconds, Headers, S3BodyKey, MessageTypeFullName]).ToFrozenSet();
+        public static readonly FrozenSet<string> NativeMessageAttributesNotCopiedToNServiceBusHeaders = new HashSet<string>([TimeToBeReceived, DelaySeconds, Headers, S3BodyKey]).ToFrozenSet();
     }
 }


### PR DESCRIPTION
This PR propagates incoming native message attributes to NServiceBus headers. If the incoming message attribute key matches an NServiceBus header key, the NServiceBus header value will be overwritten by the native message attribute value with a matching key.

The following transport-specific headers are already present on the incoming native message as message attributes:

- `NServiceBus.AmazonSQS.TimeToBeReceived`
- `NServiceBus.AmazonSQS.DelaySeconds`
- `NServiceBus.AmazonSQS.Headers`
- `NServiceBus.AmazonSQS.S3BodyKey`
- `NServiceBus.AmazonSQS.MessageTypeFullName`

They are not promoted to NServiceBus headers as the internal transport implementation uses them to determine how to handle incoming messages.

## PoA

- [x] Add PR description and labels
- [x] Documentation — https://github.com/Particular/docs.particular.net/pull/7066