### PR TITLE
Allow disabling S3 payload signing to store the message body using alternative storage to S3

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
@@ -56,6 +56,7 @@ namespace NServiceBus
     {
         public S3Settings(string bucketForLargeMessages, string keyPrefix, Amazon.S3.IAmazonS3 s3Client = null) { }
         public string BucketName { get; }
+        public bool? DisablePayloadSigning { get; set; }
         public NServiceBus.S3EncryptionMethod Encryption { get; set; }
         public string KeyPrefix { get; }
         public Amazon.S3.IAmazonS3 S3Client { get; }

--- a/src/NServiceBus.Transport.SQS/Configure/S3Settings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/S3Settings.cs
@@ -88,6 +88,13 @@ namespace NServiceBus
         public string KeyPrefix { get; }
 
         /// <summary>
+        /// When set to <c>true</c> the <c>PutObjectRequest</c>to store the message
+        /// body is not signed. This is useful to support services such as Cloudflare R2
+        /// that don't support payload signing.
+        /// </summary>
+        public bool? DisablePayloadSigning { get; set; }
+
+        /// <summary>
         /// The S3 client to use.
         /// </summary>
         public IAmazonS3 S3Client => s3Client.Instance;

--- a/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/MessageDispatcher.cs
@@ -501,7 +501,8 @@ namespace NServiceBus.Transport.SQS
             {
                 BucketName = s3.BucketName,
                 InputStream = bodyStream,
-                Key = key
+                Key = key,
+                DisablePayloadSigning = s3.DisablePayloadSigning
             };
 
             s3.NullSafeEncryption.ModifyPutRequest(putObjectRequest);


### PR DESCRIPTION
The AWS S3 SDK defaults to signing the payload of S3 put requests. However, services like Cloudflare R2 don't support the AWS signing algorithm. This PR allows disabling S3 payload signing and storing the message body using alternative storage to S3.

Fix #2498 

## PoA

- [x] Add labels and description
- [x] documentation — https://github.com/Particular/docs.particular.net/pull/7067