### PR TITLE
Improve debug message to not hide the fact that things can still complete successfully

### DIFF
--- a/src/NServiceBus.Transport.SQS/Renewal.cs
+++ b/src/NServiceBus.Transport.SQS/Renewal.cs
@@ -96,7 +96,7 @@ static class Renewal
                 if (Logger.IsDebugEnabled)
                 {
                     Logger.Debug(
-                        $"Renewing the message visibility timeout failed because the message with native ID {receivedMessage.MessageId} has already been picked up by a competing consumer.",
+                        $"Renewing the message visibility timeout failed because the message with native ID {receivedMessage.MessageId} has already been successfully completed or picked up by a competing consumer.",
                         ex);
                 }
 


### PR DESCRIPTION
While testing with Debug level I managed to confuse myself believing something is off while the code behaved exactly the way it should have. This improves the debug level statement to indicate that when the renewal fails the message might still have been successfully completed.

Needs to be backported