### PR TITLE
Fix failing command line tests

### DIFF
--- a/src/CommandLine/DefaultConfigurationValues.cs
+++ b/src/CommandLine/DefaultConfigurationValues.cs
@@ -11,10 +11,4 @@ public static class DefaultConfigurationValues
 
     public static readonly string QueueNamePrefix = string.Empty;
     public static readonly string TopicNamePrefix = string.Empty;
-
-    /* TODO: look into these, why are they different from the above?
-     public static readonly int AwsMaximumQueueDelayTime = (int)TimeSpan.FromMinutes(15).TotalSeconds;
-     public static readonly TimeSpan DelayedDeliveryQueueMessageRetentionPeriod = TimeSpan.FromDays(4);
-     public static readonly int DelayedDeliveryQueueDelayTime = Convert.ToInt32(Math.Ceiling(MaximumQueueDelayTime.TotalSeconds));
-     */
 }

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -68,12 +68,12 @@ class Program
                 createCommand.AddOption(prefixOption);
 
                 var retentionPeriodInSecondsCommand = createCommand.Option("-t|--retention",
-                    $"Retention Period in seconds (defaults to {DefaultConfigurationValues.RetentionPeriod.TotalSeconds} ) ", CommandOptionType.SingleValue);
+                    $"Retention Period in seconds (defaults to {(int)DefaultConfigurationValues.RetentionPeriod.TotalSeconds} ) ", CommandOptionType.SingleValue);
 
                 createCommand.OnExecuteAsync(async ct =>
                 {
                     var endpointName = nameArgument.Value;
-                    var retentionPeriodInSeconds = retentionPeriodInSecondsCommand.HasValue() ? double.Parse(retentionPeriodInSecondsCommand.Value()) : DefaultConfigurationValues.RetentionPeriod.TotalSeconds;
+                    var retentionPeriodInSeconds = retentionPeriodInSecondsCommand.HasValue() ? int.Parse(retentionPeriodInSecondsCommand.Value()) : (int)DefaultConfigurationValues.RetentionPeriod.TotalSeconds;
                     var prefix = prefixOption.HasValue() ? prefixOption.Value() : DefaultConfigurationValues.QueueNamePrefix;
 
                     await CommandRunner.Run(accessKeyOption, secretOption, regionOption, (sqs, sns, s3) => Endpoint.Create(sqs, prefix, endpointName, retentionPeriodInSeconds));
@@ -140,8 +140,8 @@ class Program
 
                     delayDeliverySupportCommand.OnExecuteAsync(async ct =>
                     {
-                        var delayInSeconds = DefaultConfigurationValues.MaximumQueueDelayTime.TotalSeconds;
-                        var retentionPeriodInSeconds = retentionPeriodInSecondsCommand.HasValue() ? double.Parse(retentionPeriodInSecondsCommand.Value()) : DefaultConfigurationValues.RetentionPeriod.TotalSeconds;
+                        var delayInSeconds = (int)DefaultConfigurationValues.MaximumQueueDelayTime.TotalSeconds;
+                        var retentionPeriodInSeconds = retentionPeriodInSecondsCommand.HasValue() ? int.Parse(retentionPeriodInSecondsCommand.Value()) : (int)DefaultConfigurationValues.RetentionPeriod.TotalSeconds;
                         var suffix = DefaultConfigurationValues.DelayedDeliveryQueueSuffix;
 
                         var endpointName = nameArgument.Value;

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -99,7 +99,7 @@ public class CommandLineTests
     [Test]
     public async Task Create_endpoint_with_custom_retention()
     {
-        int customRetention = 60000;
+        const int customRetention = 60000;
         (_, string error, int exitCode) =
             await Execute($"endpoint create {EndpointName} --retention {customRetention} --prefix {prefix}");
 
@@ -109,7 +109,7 @@ public class CommandLineTests
             Assert.That(error, Is.EqualTo(string.Empty));
         });
 
-        await VerifyQueue(EndpointName, prefix, customRetention);
+        await VerifyQueue(EndpointName, prefix, retentionPeriodInSeconds: customRetention);
     }
 
     [Test]
@@ -217,7 +217,7 @@ public class CommandLineTests
     [Test]
     public async Task Enable_delay_delivery_on_endpoint_with_custom_retention()
     {
-        int retention = 60000;
+        const int customRetention = 60000;
 
         (_, string error, int exitCode) = await Execute($"endpoint create {EndpointName} --prefix {prefix}");
 
@@ -229,7 +229,7 @@ public class CommandLineTests
 
         (_, error, exitCode) =
             await Execute(
-                $"endpoint add {EndpointName} delay-delivery-support --retention {retention} --prefix {prefix}");
+                $"endpoint add {EndpointName} delay-delivery-support --retention {customRetention} --prefix {prefix}");
 
         Assert.Multiple(() =>
         {
@@ -237,7 +237,7 @@ public class CommandLineTests
             Assert.That(error, Is.EqualTo(string.Empty));
         });
 
-        await VerifyDelayDeliveryQueue(EndpointName, prefix, retention);
+        await VerifyDelayDeliveryQueue(EndpointName, prefix, retentionPeriodInSeconds: customRetention);
     }
 
     [Test]


### PR DESCRIPTION
While investigating the failing tests, I discovered that we use a double while SQS only accepts seconds. I switched the parsing logic and the types to consistently use an integer.

While doing that I discovered the root problem, which is default parameter overload resolution makes the verifications sometimes fail

It would probably be nice to have this ported to the current release branch to avoid further failures.