### PR TITLE
Upgrade to AWS SDK v4

### DIFF
--- a/src/CommandLine/Bucket.cs
+++ b/src/CommandLine/Bucket.cs
@@ -32,9 +32,9 @@ static class Bucket
         await Console.Out.WriteLineAsync($"Adding lifecycle configuration to bucket name '{bucketName}' for endpoint '{endpointName}'.");
 
         var lifecycleConfig = await s3.GetLifecycleConfigurationAsync(bucketName).ConfigureAwait(false);
-        var setLifecycleConfig = lifecycleConfig.Configuration.Rules.All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
+        var setLifecycleConfig = lifecycleConfig.Configuration.Rules?.All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
 
-        if (setLifecycleConfig)
+        if (setLifecycleConfig.HasValue)
         {
             await s3.RetryConflictsAsync(async () =>
                     await s3.PutLifecycleConfigurationAsync(new PutLifecycleConfigurationRequest

--- a/src/CommandLine/Bucket.cs
+++ b/src/CommandLine/Bucket.cs
@@ -32,9 +32,9 @@ static class Bucket
         await Console.Out.WriteLineAsync($"Adding lifecycle configuration to bucket name '{bucketName}' for endpoint '{endpointName}'.");
 
         var lifecycleConfig = await s3.GetLifecycleConfigurationAsync(bucketName).ConfigureAwait(false);
-        var setLifecycleConfig = lifecycleConfig.Configuration.Rules?.All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
+        var setLifecycleConfig = (lifecycleConfig.Configuration.Rules ?? []).All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
 
-        if (setLifecycleConfig.HasValue)
+        if (setLifecycleConfig)
         {
             await s3.RetryConflictsAsync(async () =>
                     await s3.PutLifecycleConfigurationAsync(new PutLifecycleConfigurationRequest

--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.0.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.0.2" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageReference Include="Particular.Packaging" Version="4.2.2" PrivateAssets="All" />

--- a/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
+++ b/src/CommandLine/NServiceBus.Transports.SQS.CommandLine.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.416.16" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400.140" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.140" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageReference Include="Particular.Packaging" Version="4.2.2" PrivateAssets="All" />

--- a/src/CommandLine/PolicyExtensions.cs
+++ b/src/CommandLine/PolicyExtensions.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Amazon.Auth.AccessControlPolicy;
-using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
 static class PolicyExtensions
 {
@@ -177,7 +176,7 @@ static class PolicyExtensions
     static Statement CreatePermissionStatementForQueueMatching(string queueArn, IEnumerable<string> topicArnMatchPatterns)
     {
         var statement = new Statement(Statement.StatementEffect.Allow);
-        statement.Actions.Add(SQSActionIdentifiers.SendMessage);
+        statement.Actions.Add(new ActionIdentifier("sqs:SendMessage"));
         statement.Resources.Add(new Resource(queueArn));
         statement.Principals.Add(new Principal("*"));
         var queuePermissionCondition = new Condition(ConditionFactory.ArnComparisonType.ArnLike.ToString(), "aws:SourceArn", topicArnMatchPatterns.OrderBy(t => t, OrdinalComparer).ToArray());

--- a/src/CommandLine/PolicyExtensions.cs
+++ b/src/CommandLine/PolicyExtensions.cs
@@ -84,12 +84,7 @@ static class PolicyExtensions
 
     internal static Policy ExtractPolicy(this Dictionary<string, string> queueAttributes)
     {
-        string policyStr = null;
-        if (queueAttributes.ContainsKey("Policy"))
-        {
-            policyStr = queueAttributes["Policy"];
-        }
-
+        queueAttributes.TryGetValue("Policy", out string policyStr);
         return string.IsNullOrEmpty(policyStr) ? new Policy() : Policy.FromJson(policyStr);
     }
 

--- a/src/CommandLine/PolicyStatement.cs
+++ b/src/CommandLine/PolicyStatement.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Transport.SQS.CommandLine;
 
 using Amazon.Auth.AccessControlPolicy;
-using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
 class PolicyStatement
 {
@@ -22,7 +21,7 @@ class PolicyStatement
     static Statement CreatePermissionStatement(string queueArn, string topicArn)
     {
         var statement = new Statement(Statement.StatementEffect.Allow);
-        statement.Actions.Add(SQSActionIdentifiers.SendMessage);
+        statement.Actions.Add(new ActionIdentifier("sqs:SendMessage"));
         statement.Resources.Add(new Resource(queueArn));
         statement.Conditions.Add(ConditionFactory.NewSourceArnCondition(topicArn));
         statement.Principals.Add(new Principal("*"));

--- a/src/CommandLine/PolicyStatement.cs
+++ b/src/CommandLine/PolicyStatement.cs
@@ -2,20 +2,12 @@ namespace NServiceBus.Transport.SQS.CommandLine;
 
 using Amazon.Auth.AccessControlPolicy;
 
-class PolicyStatement
+class PolicyStatement(string topicName, string topicArn, string queueArn)
 {
-    public PolicyStatement(string topicName, string topicArn, string queueArn)
-    {
-        TopicName = topicName;
-        TopicArn = topicArn;
-        Statement = CreatePermissionStatement(queueArn, topicArn);
-        QueueArn = queueArn;
-    }
-
-    public string QueueArn { get; }
-    public string TopicName { get; }
-    public string TopicArn { get; }
-    public Statement Statement { get; }
+    public string QueueArn { get; } = queueArn;
+    public string TopicName { get; } = topicName;
+    public string TopicArn { get; } = topicArn;
+    public Statement Statement { get; } = CreatePermissionStatement(queueArn, topicArn);
 
 #pragma warning disable 618
     static Statement CreatePermissionStatement(string queueArn, string topicArn)

--- a/src/CommandLine/Queue.cs
+++ b/src/CommandLine/Queue.cs
@@ -30,8 +30,14 @@ static class Queue
         var sqsRequest = new CreateQueueRequest { QueueName = queueName };
         await Console.Out.WriteLineAsync($"Creating SQS Queue with name '{sqsRequest.QueueName}' for endpoint '{endpointName}'.");
         var createQueueResponse = await sqs.CreateQueueAsync(sqsRequest).ConfigureAwait(false);
-        var sqsAttributesRequest = new SetQueueAttributesRequest { QueueUrl = createQueueResponse.QueueUrl };
-        sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod, retentionPeriodInSeconds.ToString(CultureInfo.InvariantCulture));
+        var sqsAttributesRequest = new SetQueueAttributesRequest
+        {
+            QueueUrl = createQueueResponse.QueueUrl,
+            Attributes = new Dictionary<string, string>
+            {
+                { QueueAttributeName.MessageRetentionPeriod, retentionPeriodInSeconds.ToString(CultureInfo.InvariantCulture) }
+            }
+        };
         await sqs.SetQueueAttributesAsync(sqsAttributesRequest).ConfigureAwait(false);
         await Console.Out.WriteLineAsync($"Created SQS Queue with name '{sqsRequest.QueueName}' for endpoint '{endpointName}'.");
         return createQueueResponse.QueueUrl;
@@ -47,9 +53,15 @@ static class Queue
         };
         await Console.Out.WriteLineAsync($"Creating SQS delayed delivery queue with name '{sqsRequest.QueueName}' for endpoint '{endpointName}'.");
         var createQueueResponse = await sqs.CreateQueueAsync(sqsRequest).ConfigureAwait(false);
-        var sqsAttributesRequest = new SetQueueAttributesRequest { QueueUrl = createQueueResponse.QueueUrl };
-        sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod, retentionPeriodInSeconds.ToString(CultureInfo.InvariantCulture));
-        sqsAttributesRequest.Attributes.Add(QueueAttributeName.DelaySeconds, delayInSeconds.ToString(CultureInfo.InvariantCulture));
+        var sqsAttributesRequest = new SetQueueAttributesRequest
+        {
+            QueueUrl = createQueueResponse.QueueUrl,
+            Attributes = new Dictionary<string, string>
+            {
+                { QueueAttributeName.MessageRetentionPeriod, retentionPeriodInSeconds.ToString(CultureInfo.InvariantCulture) },
+                { QueueAttributeName.DelaySeconds, delayInSeconds.ToString(CultureInfo.InvariantCulture) }
+            }
+        };
         await sqs.SetQueueAttributesAsync(sqsAttributesRequest).ConfigureAwait(false);
         await Console.Out.WriteLineAsync($"Created SQS delayed delivery queue with name '{sqsRequest.QueueName}' for endpoint '{endpointName}'.");
         return createQueueResponse.QueueUrl;

--- a/src/CommandLine/Topic.cs
+++ b/src/CommandLine/Topic.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
@@ -66,7 +67,7 @@ static class Topic
             upToAHundredSubscriptions = await sns.ListSubscriptionsByTopicAsync(topicArn, upToAHundredSubscriptions?.NextToken)
                 .ConfigureAwait(false);
 
-            foreach (var upToAHundredSubscription in upToAHundredSubscriptions.Subscriptions)
+            foreach (var upToAHundredSubscription in upToAHundredSubscriptions.Subscriptions ?? Enumerable.Empty<Subscription>())
             {
                 if (upToAHundredSubscription.Endpoint == queueArn)
                 {
@@ -74,7 +75,7 @@ static class Topic
                 }
             }
         }
-        while (upToAHundredSubscriptions.NextToken != null && upToAHundredSubscriptions.Subscriptions.Count > 0);
+        while (upToAHundredSubscriptions.NextToken != null && upToAHundredSubscriptions.Subscriptions is { Count: > 0 });
 
         return null;
     }

--- a/src/CommandLineTests/CommandLineTests.cs
+++ b/src/CommandLineTests/CommandLineTests.cs
@@ -960,7 +960,7 @@ public class CommandLineTests
             GetLifecycleConfigurationResponse lifecycleConfig =
                 await s3Client.GetLifecycleConfigurationAsync(bucketName);
             setLifeCycleConfig =
-                lifecycleConfig.Configuration.Rules.FirstOrDefault(x => x.Id == "NServiceBus.SQS.DeleteMessageBodies");
+                lifecycleConfig.Configuration.Rules?.FirstOrDefault(x => x.Id == "NServiceBus.SQS.DeleteMessageBodies");
         } while (setLifeCycleConfig == null && backOff < MaximumBackoffInterval);
 
         Assert.That(setLifeCycleConfig, Is.Not.Null);
@@ -982,14 +982,14 @@ public class CommandLineTests
             upToAHundredSubscriptions =
                 await snsClient.ListSubscriptionsByTopicAsync(topicArn, upToAHundredSubscriptions?.NextToken);
 
-            foreach (Subscription upToAHundredSubscription in upToAHundredSubscriptions.Subscriptions)
+            foreach (Subscription upToAHundredSubscription in upToAHundredSubscriptions.Subscriptions ?? Enumerable.Empty<Subscription>())
             {
                 if (upToAHundredSubscription.Endpoint == queueArn)
                 {
                     subscription = upToAHundredSubscription;
                 }
             }
-        } while (upToAHundredSubscriptions.NextToken != null && upToAHundredSubscriptions.Subscriptions.Count > 0);
+        } while (upToAHundredSubscriptions.NextToken != null && upToAHundredSubscriptions.Subscriptions is { Count: > 0 });
 
         Assert.That(subscription, Is.Not.Null);
     }
@@ -1002,17 +1002,16 @@ public class CommandLineTests
         do
         {
             upToAHundredSubscriptions =
-                await snsClient.ListSubscriptionsByTopicAsync(topicArn, upToAHundredSubscriptions?.NextToken)
-                ;
+                await snsClient.ListSubscriptionsByTopicAsync(topicArn, upToAHundredSubscriptions?.NextToken);
 
-            foreach (Subscription upToAHundredSubscription in upToAHundredSubscriptions.Subscriptions)
+            foreach (Subscription upToAHundredSubscription in upToAHundredSubscriptions.Subscriptions ?? Enumerable.Empty<Subscription>())
             {
                 if (upToAHundredSubscription.Endpoint == queueArn)
                 {
                     subscription = upToAHundredSubscription;
                 }
             }
-        } while (upToAHundredSubscriptions.NextToken != null && upToAHundredSubscriptions.Subscriptions.Count > 0);
+        } while (upToAHundredSubscriptions.NextToken != null && upToAHundredSubscriptions.Subscriptions is { Count: > 0 });
 
         Assert.That(subscription, Is.Null);
     }

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/NativeEndpoint.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativeIntegration/NativeEndpoint.cs
@@ -33,8 +33,7 @@ static class NativeEndpoint
 
             foreach (var msg in receiveMessageResponse.Messages)
             {
-                msg.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute);
-                if (messageIdAttribute?.StringValue == testRunId.ToString())
+                if (msg.MessageAttributes?.TryGetValue(Headers.MessageId, out var messageIdAttribute) is true && messageIdAttribute?.StringValue == testRunId.ToString())
                 {
                     nativeMessageAccessor?.Invoke(msg);
                 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/MessageDispatcherTests.Should_not_wrap_if_configured_not_to.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/MessageDispatcherTests.Should_not_wrap_if_configured_not_to.approved.txt
@@ -2,23 +2,23 @@
   "DelaySeconds": 0,
   "MessageAttributes": {
     "NServiceBus.MessageId": {
-      "BinaryListValues": [],
+      "BinaryListValues": null,
       "BinaryValue": null,
       "DataType": "String",
-      "StringListValues": [],
+      "StringListValues": null,
       "StringValue": "1234"
     },
     "NServiceBus.AmazonSQS.Headers": {
-      "BinaryListValues": [],
+      "BinaryListValues": null,
       "BinaryValue": null,
       "DataType": "String",
-      "StringListValues": [],
+      "StringListValues": null,
       "StringValue": "{\"NServiceBus.AmazonSQS.TimeToBeReceived\":\"10675199.01:48:05.4775807\",\"NServiceBus.ReplyToAddress\":\"TestReplyToAddress\",\"NServiceBus.MessageId\":\"74d4f8e4-0fc7-4f09-8d46-0b76994e76d6\"}"
     }
   },
   "MessageBody": "my message body",
   "MessageDeduplicationId": null,
   "MessageGroupId": null,
-  "MessageSystemAttributes": {},
+  "MessageSystemAttributes": null,
   "QueueUrl": "address"
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_sets_full_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_sets_full_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_account_condition_sets_full_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_account_condition_sets_full_policy.approved.txt
@@ -1,18 +1,18 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : "arn:aws:sns:us-west-2:123456789012:*"
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:sns:us-west-2:123456789012:*"
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_all_conditions_sets_full_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_all_conditions_sets_full_policy.approved.txt
@@ -1,23 +1,23 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-Sales-HighValueOrders-*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-Shipping-*"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-Sales-HighValueOrders-*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-Shipping-*"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_all_conditions_sets_full_policy_with_replaced_wildcard.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_all_conditions_sets_full_policy_with_replaced_wildcard.approved.txt
@@ -1,18 +1,18 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : "arn:aws:sns:us-west-2:123456789012:*"
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:sns:us-west-2:123456789012:*"
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_empty_add_statements_doesnt_update_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_empty_add_statements_doesnt_update_policy.approved.txt
@@ -1,5 +1,4 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-    ]
+  "Version": "2012-10-17",
+  "Statement": []
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_legacy_policy_does_migrate_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_legacy_policy_does_migrate_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_legacy_policy_with_conditions_does_migrate_to_wildcard_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_legacy_policy_with_conditions_does_migrate_to_wildcard_policy.approved.txt
@@ -1,22 +1,22 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_does_migrate_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_does_migrate_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_migration_leaves_unrelated_permissions.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_migration_leaves_unrelated_permissions.approved.txt
@@ -1,34 +1,34 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : "arn:aws:sns:us-west-2:123456789012:UnrelatedEvent"
-                }
-            }
-        },
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:sns:us-west-2:123456789012:UnrelatedEvent"
         }
-    ]
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_with_condition_migration_leaves_unrelated_permissions.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_with_condition_migration_leaves_unrelated_permissions.approved.txt
@@ -1,35 +1,35 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : "arn:aws:sns:us-west-2:123456789012:DEV-UnrelatedEvent"
-                }
-            }
-        },
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:sns:us-west-2:123456789012:DEV-UnrelatedEvent"
         }
-    ]
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_with_conditions_does_migrate_to_wildcard_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_legacy_policy_with_conditions_does_migrate_to_wildcard_policy.approved.txt
@@ -1,22 +1,22 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_policy_migration_leaves_unrelated_permissions.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_partial_policy_migration_leaves_unrelated_permissions.approved.txt
@@ -1,35 +1,35 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : "arn:aws:sns:us-west-2:123456789012:UnrelatedEvent"
-                }
-            }
-        },
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-YetAnotherEvent"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:sns:us-west-2:123456789012:UnrelatedEvent"
         }
-    ]
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-YetAnotherEvent"
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_does_extend_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_does_extend_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_matching_but_different_order_doesnt_override_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_matching_but_different_order_doesnt_override_policy.approved.txt
@@ -1,23 +1,23 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-YetAnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-YetYetAnotherEvent"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-YetAnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-YetYetAnotherEvent"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_matching_doesnt_override_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_matching_doesnt_override_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_switched_to_wildcard.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_policy_switched_to_wildcard.approved.txt
@@ -1,22 +1,22 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-*"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_wildcard_policy_switched_to_events_will_replace_wildcards.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_existing_wildcard_policy_switched_to_events_will_replace_wildcards.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_namespace_conditions_and_topic_name_prefix_sets_full_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_namespace_conditions_and_topic_name_prefix_sets_full_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:DEV-Sales-HighValueOrders-*",
-                        "arn:aws:sns:us-west-2:123456789012:DEV-Shipping-*"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:DEV-Sales-HighValueOrders-*",
+            "arn:aws:sns:us-west-2:123456789012:DEV-Shipping-*"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_namespace_conditions_sets_full_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_namespace_conditions_sets_full_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:Sales-HighValueOrders-*",
-                        "arn:aws:sns:us-west-2:123456789012:Shipping-*"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:Sales-HighValueOrders-*",
+            "arn:aws:sns:us-west-2:123456789012:Shipping-*"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_nothing_to_subscribe_doesnt_override_existing_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_nothing_to_subscribe_doesnt_override_existing_policy.approved.txt
@@ -1,21 +1,21 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : [
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
-                        "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
-                    ]
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": [
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-AnotherEvent",
+            "arn:aws:sns:us-west-2:123456789012:NServiceBus-Transport-SQS-Tests-SubscriptionManagerTests-Event"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_topic_name_prefix_sets_full_policy.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/PolicyExtensionsTests.Update_with_topic_name_prefix_sets_full_policy.approved.txt
@@ -1,18 +1,18 @@
 {
-    "Version" : "2012-10-17",
-    "Statement" : [
-        {
-            "Effect" : "Allow",
-            "Principal" : {
-                "AWS" : "*"
-            },
-            "Action"    : "sqs:SendMessage",
-            "Resource"  : "arn:fakeQueue",
-            "Condition" : {
-                "ArnLike" : {
-                    "aws:SourceArn" : "arn:aws:sns:us-west-2:123456789012:DEV-*"
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:fakeQueue",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:sns:us-west-2:123456789012:DEV-*"
         }
-    ]
+      }
+    }
+  ]
 }

--- a/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
@@ -29,6 +29,9 @@ public class MockS3Client : IAmazonS3
 
     #region NotImplemented
 
+    public Task<PutObjectAclResponse> PutObjectAclAsync(PutObjectAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+
+
     public PutObjectLegalHoldResponse PutObjectLegalHold(PutObjectLegalHoldRequest request)
     {
         throw new NotImplementedException();
@@ -232,6 +235,15 @@ public class MockS3Client : IAmazonS3
     {
         throw new NotImplementedException();
     }
+
+    public Task<CopyPartResponse> CopyPartAsync(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey,
+        string uploadId, int? partNumber, CancellationToken cancellationToken = new CancellationToken()) =>
+        throw new NotImplementedException();
+
+    public Task<CopyPartResponse> CopyPartAsync(string sourceBucket, string sourceKey, string sourceVersionId, string destinationBucket,
+        string destinationKey, string uploadId, int? partNumber,
+        CancellationToken cancellationToken = new CancellationToken()) =>
+        throw new NotImplementedException();
 
     public CopyPartResponse CopyPart(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey, string uploadId)
     {
@@ -554,6 +566,8 @@ public class MockS3Client : IAmazonS3
         throw new NotImplementedException();
     }
 
+    public Task<GetBucketAclResponse> GetBucketAclAsync(GetBucketAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+
     public GetBucketAnalyticsConfigurationResponse GetBucketAnalyticsConfiguration(GetBucketAnalyticsConfigurationRequest request)
     {
         throw new NotImplementedException();
@@ -848,6 +862,8 @@ public class MockS3Client : IAmazonS3
     {
         throw new NotImplementedException();
     }
+
+    public Task<GetObjectAclResponse> GetObjectAclAsync(GetObjectAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
 
     public GetObjectLegalHoldResponse GetObjectLegalHold(GetObjectLegalHoldRequest request)
     {
@@ -1185,6 +1201,8 @@ public class MockS3Client : IAmazonS3
         throw new NotImplementedException();
     }
 
+    public Task<PutBucketAclResponse> PutBucketAclAsync(PutBucketAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+
     public PutBucketAnalyticsConfigurationResponse PutBucketAnalyticsConfiguration(PutBucketAnalyticsConfigurationRequest request)
     {
         throw new NotImplementedException();
@@ -1461,6 +1479,10 @@ public class MockS3Client : IAmazonS3
         throw new NotImplementedException();
     }
 
+    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, int? days,
+        CancellationToken cancellationToken = new CancellationToken()) =>
+        throw new NotImplementedException();
+
     public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, int days, CancellationToken cancellationToken = new CancellationToken())
     {
         throw new NotImplementedException();
@@ -1470,6 +1492,10 @@ public class MockS3Client : IAmazonS3
     {
         throw new NotImplementedException();
     }
+
+    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, string versionId, int? days,
+        CancellationToken cancellationToken = new CancellationToken()) =>
+        throw new NotImplementedException();
 
     public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, string versionId, int days, CancellationToken cancellationToken = new CancellationToken())
     {

--- a/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockS3Client.cs
@@ -17,7 +17,7 @@ public class MockS3Client : IAmazonS3
 
     public Func<PutObjectRequest, PutObjectResponse> PutObjectRequestResponse = req => new PutObjectResponse();
 
-    public Task<PutObjectResponse> PutObjectAsync(PutObjectRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<PutObjectResponse> PutObjectAsync(PutObjectRequest request, CancellationToken cancellationToken = default)
     {
         PutObjectRequestsSent.Enqueue(request);
         return Task.FromResult(PutObjectRequestResponse(request));
@@ -29,1529 +29,353 @@ public class MockS3Client : IAmazonS3
 
     #region NotImplemented
 
-    public Task<PutObjectAclResponse> PutObjectAclAsync(PutObjectAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+    public Task<PutObjectAclResponse> PutObjectAclAsync(PutObjectAclRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
+    public Task<PutObjectLegalHoldResponse> PutObjectLegalHoldAsync(PutObjectLegalHoldRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutObjectLegalHoldResponse PutObjectLegalHold(PutObjectLegalHoldRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutObjectLockConfigurationResponse> PutObjectLockConfigurationAsync(PutObjectLockConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutObjectLegalHoldResponse> PutObjectLegalHoldAsync(PutObjectLegalHoldRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutObjectRetentionResponse> PutObjectRetentionAsync(PutObjectRetentionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutObjectLockConfigurationResponse PutObjectLockConfiguration(PutObjectLockConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public string GeneratePreSignedURL(string bucketName, string objectKey, DateTime expiration, IDictionary<string, object> additionalProperties) => throw new NotImplementedException();
 
-    public Task<PutObjectLockConfigurationResponse> PutObjectLockConfigurationAsync(PutObjectLockConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<IList<string>> GetAllObjectKeysAsync(string bucketName, string prefix, IDictionary<string, object> additionalProperties) => throw new NotImplementedException();
 
-    public PutObjectRetentionResponse PutObjectRetention(PutObjectRetentionRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task UploadObjectFromStreamAsync(string bucketName, string objectKey, Stream stream, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutObjectRetentionResponse> PutObjectRetentionAsync(PutObjectRetentionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task DeleteAsync(string bucketName, string objectKey, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public string GeneratePreSignedURL(string bucketName, string objectKey, DateTime expiration, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
+    public Task DeletesAsync(string bucketName, IEnumerable<string> objectKeys, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<IList<string>> GetAllObjectKeysAsync(string bucketName, string prefix, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<Stream> GetObjectStreamAsync(string bucketName, string objectKey, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task UploadObjectFromStreamAsync(string bucketName, string objectKey, Stream stream, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task UploadObjectFromFilePathAsync(string bucketName, string objectKey, string filepath, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task DeleteAsync(string bucketName, string objectKey, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task DownloadToFilePathAsync(string bucketName, string objectKey, string filepath, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task DeletesAsync(string bucketName, IEnumerable<string> objectKeys, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task MakeObjectPublicAsync(string bucketName, string objectKey, bool enable) => throw new NotImplementedException();
 
-    public Task<Stream> GetObjectStreamAsync(string bucketName, string objectKey, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task UploadObjectFromFilePathAsync(string bucketName, string objectKey, string filepath, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task DownloadToFilePathAsync(string bucketName, string objectKey, string filepath, IDictionary<string, object> additionalProperties, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task MakeObjectPublicAsync(string bucketName, string objectKey, bool enable)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task EnsureBucketExistsAsync(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<bool> DoesS3BucketExistAsync(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IList<string> GetAllObjectKeys(string bucketName, string prefix, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void Delete(string bucketName, string objectKey, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void Deletes(string bucketName, IEnumerable<string> objectKeys, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void UploadObjectFromStream(string bucketName, string objectKey, Stream stream, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void UploadObjectFromFilePath(string bucketName, string objectKey, string filepath, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void DownloadToFilePath(string bucketName, string objectKey, string filepath, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Stream GetObjectStream(string bucketName, string objectKey, IDictionary<string, object> additionalProperties)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void MakeObjectPublic(string bucketName, string objectKey, bool enable)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void EnsureBucketExists(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public bool DoesS3BucketExist(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task EnsureBucketExistsAsync(string bucketName) => throw new NotImplementedException();
 
     public IClientConfig Config { get; }
 
-    public string GetPreSignedURL(GetPreSignedUrlRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public string GetPreSignedURL(GetPreSignedUrlRequest request) => throw new NotImplementedException();
 
     public Task<string> GetPreSignedURLAsync(GetPreSignedUrlRequest request) => throw new NotImplementedException();
 
-    public AbortMultipartUploadResponse AbortMultipartUpload(string bucketName, string key, string uploadId)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<AbortMultipartUploadResponse> AbortMultipartUploadAsync(string bucketName, string key, string uploadId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public AbortMultipartUploadResponse AbortMultipartUpload(AbortMultipartUploadRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<AbortMultipartUploadResponse> AbortMultipartUploadAsync(AbortMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<AbortMultipartUploadResponse> AbortMultipartUploadAsync(string bucketName, string key, string uploadId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<CompleteMultipartUploadResponse> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<AbortMultipartUploadResponse> AbortMultipartUploadAsync(AbortMultipartUploadRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<CopyObjectResponse> CopyObjectAsync(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public CompleteMultipartUploadResponse CompleteMultipartUpload(CompleteMultipartUploadRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<CopyObjectResponse> CopyObjectAsync(string sourceBucket, string sourceKey, string sourceVersionId, string destinationBucket, string destinationKey, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<CompleteMultipartUploadResponse> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CopyObjectResponse CopyObject(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey)
-    {
-        throw new NotImplementedException();
-    }
-
-    public CopyObjectResponse CopyObject(string sourceBucket, string sourceKey, string sourceVersionId, string destinationBucket, string destinationKey)
-    {
-        throw new NotImplementedException();
-    }
-
-    public CopyObjectResponse CopyObject(CopyObjectRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CopyObjectResponse> CopyObjectAsync(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CopyObjectResponse> CopyObjectAsync(string sourceBucket, string sourceKey, string sourceVersionId, string destinationBucket, string destinationKey, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CopyObjectResponse> CopyObjectAsync(CopyObjectRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<CopyObjectResponse> CopyObjectAsync(CopyObjectRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<CopyPartResponse> CopyPartAsync(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey,
-        string uploadId, int? partNumber, CancellationToken cancellationToken = new CancellationToken()) =>
+        string uploadId, int? partNumber, CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
     public Task<CopyPartResponse> CopyPartAsync(string sourceBucket, string sourceKey, string sourceVersionId, string destinationBucket,
         string destinationKey, string uploadId, int? partNumber,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public CopyPartResponse CopyPart(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey, string uploadId)
-    {
-        throw new NotImplementedException();
-    }
-
-    public CopyPartResponse CopyPart(string sourceBucket, string sourceKey, string sourceVersionId, string destinationBucket, string destinationKey, string uploadId)
-    {
-        throw new NotImplementedException();
-    }
-
-    public CopyPartResponse CopyPart(CopyPartRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CopyPartResponse> CopyPartAsync(string sourceBucket, string sourceKey, string destinationBucket, string destinationKey, string uploadId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CopyPartResponse> CopyPartAsync(string sourceBucket, string sourceKey, string sourceVersionId, string destinationBucket, string destinationKey, string uploadId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CopyPartResponse> CopyPartAsync(CopyPartRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<CopyPartResponse> CopyPartAsync(CopyPartRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<CreateBucketMetadataTableConfigurationResponse> CreateBucketMetadataTableConfigurationAsync(CreateBucketMetadataTableConfigurationRequest request,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public Task<CreateSessionResponse> CreateSessionAsync(CreateSessionRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+    public Task<CreateSessionResponse> CreateSessionAsync(CreateSessionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketResponse DeleteBucket(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketResponse> DeleteBucketAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketResponse DeleteBucket(DeleteBucketRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketResponse> DeleteBucketAsync(DeleteBucketRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketResponse> DeleteBucketAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketAnalyticsConfigurationResponse> DeleteBucketAnalyticsConfigurationAsync(DeleteBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketResponse> DeleteBucketAsync(DeleteBucketRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketEncryptionResponse> DeleteBucketEncryptionAsync(DeleteBucketEncryptionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketAnalyticsConfigurationResponse DeleteBucketAnalyticsConfiguration(DeleteBucketAnalyticsConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteBucketAnalyticsConfigurationResponse> DeleteBucketAnalyticsConfigurationAsync(DeleteBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteBucketEncryptionResponse DeleteBucketEncryption(DeleteBucketEncryptionRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteBucketEncryptionResponse> DeleteBucketEncryptionAsync(DeleteBucketEncryptionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteBucketInventoryConfigurationResponse DeleteBucketInventoryConfiguration(DeleteBucketInventoryConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteBucketInventoryConfigurationResponse> DeleteBucketInventoryConfigurationAsync(DeleteBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketInventoryConfigurationResponse> DeleteBucketInventoryConfigurationAsync(DeleteBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<DeleteBucketMetadataTableConfigurationResponse> DeleteBucketMetadataTableConfigurationAsync(DeleteBucketMetadataTableConfigurationRequest request,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public DeleteBucketMetricsConfigurationResponse DeleteBucketMetricsConfiguration(DeleteBucketMetricsConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteBucketMetricsConfigurationResponse> DeleteBucketMetricsConfigurationAsync(DeleteBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteBucketOwnershipControlsResponse DeleteBucketOwnershipControls(DeleteBucketOwnershipControlsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketMetricsConfigurationResponse> DeleteBucketMetricsConfigurationAsync(DeleteBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<DeleteBucketOwnershipControlsResponse> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request,
-        CancellationToken cancellationToken = new CancellationToken())
-    {
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
-    }
 
-    public DeleteBucketPolicyResponse DeleteBucketPolicy(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketPolicyResponse> DeleteBucketPolicyAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketPolicyResponse DeleteBucketPolicy(DeleteBucketPolicyRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketPolicyResponse> DeleteBucketPolicyAsync(DeleteBucketPolicyRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketPolicyResponse> DeleteBucketPolicyAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketReplicationResponse> DeleteBucketReplicationAsync(DeleteBucketReplicationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketPolicyResponse> DeleteBucketPolicyAsync(DeleteBucketPolicyRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketTaggingResponse> DeleteBucketTaggingAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketReplicationResponse DeleteBucketReplication(DeleteBucketReplicationRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketTaggingResponse> DeleteBucketTaggingAsync(DeleteBucketTaggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketReplicationResponse> DeleteBucketReplicationAsync(DeleteBucketReplicationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketWebsiteResponse> DeleteBucketWebsiteAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketTaggingResponse DeleteBucketTagging(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteBucketWebsiteResponse> DeleteBucketWebsiteAsync(DeleteBucketWebsiteRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketTaggingResponse DeleteBucketTagging(DeleteBucketTaggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteCORSConfigurationResponse> DeleteCORSConfigurationAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketTaggingResponse> DeleteBucketTaggingAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteCORSConfigurationResponse> DeleteCORSConfigurationAsync(DeleteCORSConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketTaggingResponse> DeleteBucketTaggingAsync(DeleteBucketTaggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteLifecycleConfigurationResponse> DeleteLifecycleConfigurationAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketWebsiteResponse DeleteBucketWebsite(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteLifecycleConfigurationResponse> DeleteLifecycleConfigurationAsync(DeleteLifecycleConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteBucketWebsiteResponse DeleteBucketWebsite(DeleteBucketWebsiteRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteObjectResponse> DeleteObjectAsync(string bucketName, string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketWebsiteResponse> DeleteBucketWebsiteAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteObjectResponse> DeleteObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteBucketWebsiteResponse> DeleteBucketWebsiteAsync(DeleteBucketWebsiteRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteObjectResponse> DeleteObjectAsync(DeleteObjectRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteCORSConfigurationResponse DeleteCORSConfiguration(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteObjectsResponse> DeleteObjectsAsync(DeleteObjectsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteCORSConfigurationResponse DeleteCORSConfiguration(DeleteCORSConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteObjectTaggingResponse> DeleteObjectTaggingAsync(DeleteObjectTaggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteCORSConfigurationResponse> DeleteCORSConfigurationAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeletePublicAccessBlockResponse> DeletePublicAccessBlockAsync(DeletePublicAccessBlockRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteCORSConfigurationResponse> DeleteCORSConfigurationAsync(DeleteCORSConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetACLResponse> GetACLAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteLifecycleConfigurationResponse DeleteLifecycleConfiguration(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetACLResponse> GetACLAsync(GetACLRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteLifecycleConfigurationResponse DeleteLifecycleConfiguration(DeleteLifecycleConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketAccelerateConfigurationResponse> GetBucketAccelerateConfigurationAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteLifecycleConfigurationResponse> DeleteLifecycleConfigurationAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketAccelerateConfigurationResponse> GetBucketAccelerateConfigurationAsync(GetBucketAccelerateConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteLifecycleConfigurationResponse> DeleteLifecycleConfigurationAsync(DeleteLifecycleConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketAclResponse> GetBucketAclAsync(GetBucketAclRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteObjectResponse DeleteObject(string bucketName, string key)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketAnalyticsConfigurationResponse> GetBucketAnalyticsConfigurationAsync(GetBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteObjectResponse DeleteObject(string bucketName, string key, string versionId)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketEncryptionResponse> GetBucketEncryptionAsync(GetBucketEncryptionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteObjectResponse DeleteObject(DeleteObjectRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketInventoryConfigurationResponse> GetBucketInventoryConfigurationAsync(GetBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteObjectResponse> DeleteObjectAsync(string bucketName, string key, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketLocationResponse> GetBucketLocationAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteObjectResponse> DeleteObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketLocationResponse> GetBucketLocationAsync(GetBucketLocationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<DeleteObjectResponse> DeleteObjectAsync(DeleteObjectRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketLoggingResponse> GetBucketLoggingAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public DeleteObjectsResponse DeleteObjects(DeleteObjectsRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteObjectsResponse> DeleteObjectsAsync(DeleteObjectsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteObjectTaggingResponse DeleteObjectTagging(DeleteObjectTaggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteObjectTaggingResponse> DeleteObjectTaggingAsync(DeleteObjectTaggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeletePublicAccessBlockResponse DeletePublicAccessBlock(DeletePublicAccessBlockRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeletePublicAccessBlockResponse> DeletePublicAccessBlockAsync(DeletePublicAccessBlockRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetACLResponse GetACL(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetACLResponse GetACL(GetACLRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetACLResponse> GetACLAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetACLResponse> GetACLAsync(GetACLRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketAccelerateConfigurationResponse GetBucketAccelerateConfiguration(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketAccelerateConfigurationResponse GetBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketAccelerateConfigurationResponse> GetBucketAccelerateConfigurationAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketAccelerateConfigurationResponse> GetBucketAccelerateConfigurationAsync(GetBucketAccelerateConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketAclResponse> GetBucketAclAsync(GetBucketAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
-
-    public GetBucketAnalyticsConfigurationResponse GetBucketAnalyticsConfiguration(GetBucketAnalyticsConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketAnalyticsConfigurationResponse> GetBucketAnalyticsConfigurationAsync(GetBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketEncryptionResponse GetBucketEncryption(GetBucketEncryptionRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketEncryptionResponse> GetBucketEncryptionAsync(GetBucketEncryptionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketInventoryConfigurationResponse GetBucketInventoryConfiguration(GetBucketInventoryConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketInventoryConfigurationResponse> GetBucketInventoryConfigurationAsync(GetBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketLocationResponse GetBucketLocation(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketLocationResponse GetBucketLocation(GetBucketLocationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketLocationResponse> GetBucketLocationAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketLocationResponse> GetBucketLocationAsync(GetBucketLocationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketLoggingResponse GetBucketLogging(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketLoggingResponse GetBucketLogging(GetBucketLoggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketLoggingResponse> GetBucketLoggingAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketLoggingResponse> GetBucketLoggingAsync(GetBucketLoggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketLoggingResponse> GetBucketLoggingAsync(GetBucketLoggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<GetBucketMetadataTableConfigurationResponse> GetBucketMetadataTableConfigurationAsync(GetBucketMetadataTableConfigurationRequest request,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public GetBucketMetricsConfigurationResponse GetBucketMetricsConfiguration(GetBucketMetricsConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketMetricsConfigurationResponse> GetBucketMetricsConfigurationAsync(GetBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetBucketMetricsConfigurationResponse> GetBucketMetricsConfigurationAsync(GetBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketNotificationResponse> GetBucketNotificationAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetBucketNotificationResponse GetBucketNotification(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketNotificationResponse GetBucketNotification(GetBucketNotificationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketNotificationResponse> GetBucketNotificationAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketNotificationResponse> GetBucketNotificationAsync(GetBucketNotificationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketOwnershipControlsResponse GetBucketOwnershipControls(GetBucketOwnershipControlsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketNotificationResponse> GetBucketNotificationAsync(GetBucketNotificationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<GetBucketOwnershipControlsResponse> GetBucketOwnershipControlsAsync(GetBucketOwnershipControlsRequest request,
-        CancellationToken cancellationToken = new CancellationToken())
-    {
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
-    }
 
-    public GetBucketPolicyResponse GetBucketPolicy(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketPolicyResponse GetBucketPolicy(GetBucketPolicyRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketPolicyResponse> GetBucketPolicyAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketPolicyResponse> GetBucketPolicyAsync(GetBucketPolicyRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketPolicyStatusResponse GetBucketPolicyStatus(GetBucketPolicyStatusRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketPolicyStatusResponse> GetBucketPolicyStatusAsync(GetBucketPolicyStatusRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketReplicationResponse GetBucketReplication(GetBucketReplicationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketReplicationResponse> GetBucketReplicationAsync(GetBucketReplicationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketRequestPaymentResponse GetBucketRequestPayment(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketRequestPaymentResponse GetBucketRequestPayment(GetBucketRequestPaymentRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketRequestPaymentResponse> GetBucketRequestPaymentAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketRequestPaymentResponse> GetBucketRequestPaymentAsync(GetBucketRequestPaymentRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketTaggingResponse GetBucketTagging(GetBucketTaggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketTaggingResponse> GetBucketTaggingAsync(GetBucketTaggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketVersioningResponse GetBucketVersioning(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketVersioningResponse GetBucketVersioning(GetBucketVersioningRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketVersioningResponse> GetBucketVersioningAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketVersioningResponse> GetBucketVersioningAsync(GetBucketVersioningRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketWebsiteResponse GetBucketWebsite(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetBucketWebsiteResponse GetBucketWebsite(GetBucketWebsiteRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketWebsiteResponse> GetBucketWebsiteAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetBucketWebsiteResponse> GetBucketWebsiteAsync(GetBucketWebsiteRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetCORSConfigurationResponse GetCORSConfiguration(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetCORSConfigurationResponse GetCORSConfiguration(GetCORSConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetCORSConfigurationResponse> GetCORSConfigurationAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetCORSConfigurationResponse> GetCORSConfigurationAsync(GetCORSConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketPolicyResponse> GetBucketPolicyAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetLifecycleConfigurationResponse GetLifecycleConfiguration(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetLifecycleConfigurationResponse GetLifecycleConfiguration(GetLifecycleConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetLifecycleConfigurationResponse> GetLifecycleConfigurationAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetLifecycleConfigurationResponse> GetLifecycleConfigurationAsync(GetLifecycleConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetObjectResponse GetObject(string bucketName, string key)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetObjectResponse GetObject(string bucketName, string key, string versionId)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetObjectResponse GetObject(GetObjectRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketPolicyResponse> GetBucketPolicyAsync(GetBucketPolicyRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketPolicyStatusResponse> GetBucketPolicyStatusAsync(GetBucketPolicyStatusRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectResponse> GetObjectAsync(GetObjectRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketReplicationResponse> GetBucketReplicationAsync(GetBucketReplicationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectAclResponse> GetObjectAclAsync(GetObjectAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
-
-    public GetObjectLegalHoldResponse GetObjectLegalHold(GetObjectLegalHoldRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketRequestPaymentResponse> GetBucketRequestPaymentAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectLegalHoldResponse> GetObjectLegalHoldAsync(GetObjectLegalHoldRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketRequestPaymentResponse> GetBucketRequestPaymentAsync(GetBucketRequestPaymentRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectLockConfigurationResponse GetObjectLockConfiguration(GetObjectLockConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketTaggingResponse> GetBucketTaggingAsync(GetBucketTaggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectLockConfigurationResponse> GetObjectLockConfigurationAsync(GetObjectLockConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketVersioningResponse> GetBucketVersioningAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectMetadataResponse GetObjectMetadata(string bucketName, string key)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketVersioningResponse> GetBucketVersioningAsync(GetBucketVersioningRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectMetadataResponse GetObjectMetadata(string bucketName, string key, string versionId)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketWebsiteResponse> GetBucketWebsiteAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectMetadataResponse GetObjectMetadata(GetObjectMetadataRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetBucketWebsiteResponse> GetBucketWebsiteAsync(GetBucketWebsiteRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectMetadataResponse> GetObjectMetadataAsync(string bucketName, string key, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetCORSConfigurationResponse> GetCORSConfigurationAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectMetadataResponse> GetObjectMetadataAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetCORSConfigurationResponse> GetCORSConfigurationAsync(GetCORSConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectMetadataResponse> GetObjectMetadataAsync(GetObjectMetadataRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetLifecycleConfigurationResponse> GetLifecycleConfigurationAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectRetentionResponse GetObjectRetention(GetObjectRetentionRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetLifecycleConfigurationResponse> GetLifecycleConfigurationAsync(GetLifecycleConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectRetentionResponse> GetObjectRetentionAsync(GetObjectRetentionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectTaggingResponse GetObjectTagging(GetObjectTaggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectResponse> GetObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectTaggingResponse> GetObjectTaggingAsync(GetObjectTaggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectResponse> GetObjectAsync(GetObjectRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectTorrentResponse GetObjectTorrent(string bucketName, string key)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectAclResponse> GetObjectAclAsync(GetObjectAclRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public GetObjectTorrentResponse GetObjectTorrent(GetObjectTorrentRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public GetObjectLegalHoldResponse GetObjectLegalHold(GetObjectLegalHoldRequest request) => throw new NotImplementedException();
 
-    public Task<GetObjectTorrentResponse> GetObjectTorrentAsync(string bucketName, string key, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectLegalHoldResponse> GetObjectLegalHoldAsync(GetObjectLegalHoldRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetObjectTorrentResponse> GetObjectTorrentAsync(GetObjectTorrentRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public GetObjectLockConfigurationResponse GetObjectLockConfiguration(GetObjectLockConfigurationRequest request) => throw new NotImplementedException();
 
-    public GetPublicAccessBlockResponse GetPublicAccessBlock(GetPublicAccessBlockRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectLockConfigurationResponse> GetObjectLockConfigurationAsync(GetObjectLockConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<GetPublicAccessBlockResponse> GetPublicAccessBlockAsync(GetPublicAccessBlockRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectMetadataResponse> GetObjectMetadataAsync(string bucketName, string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<HeadBucketResponse> HeadBucketAsync(HeadBucketRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+    public Task<GetObjectMetadataResponse> GetObjectMetadataAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public InitiateMultipartUploadResponse InitiateMultipartUpload(string bucketName, string key)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectMetadataResponse> GetObjectMetadataAsync(GetObjectMetadataRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public InitiateMultipartUploadResponse InitiateMultipartUpload(InitiateMultipartUploadRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectRetentionResponse> GetObjectRetentionAsync(GetObjectRetentionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(string bucketName, string key, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectTaggingResponse> GetObjectTaggingAsync(GetObjectTaggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectTorrentResponse> GetObjectTorrentAsync(string bucketName, string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListBucketAnalyticsConfigurationsResponse ListBucketAnalyticsConfigurations(ListBucketAnalyticsConfigurationsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetObjectTorrentResponse> GetObjectTorrentAsync(GetObjectTorrentRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListBucketAnalyticsConfigurationsResponse> ListBucketAnalyticsConfigurationsAsync(ListBucketAnalyticsConfigurationsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetPublicAccessBlockResponse> GetPublicAccessBlockAsync(GetPublicAccessBlockRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListBucketInventoryConfigurationsResponse ListBucketInventoryConfigurations(ListBucketInventoryConfigurationsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<HeadBucketResponse> HeadBucketAsync(HeadBucketRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListBucketInventoryConfigurationsResponse> ListBucketInventoryConfigurationsAsync(ListBucketInventoryConfigurationsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(string bucketName, string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListBucketMetricsConfigurationsResponse ListBucketMetricsConfigurations(ListBucketMetricsConfigurationsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<InitiateMultipartUploadResponse> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListBucketMetricsConfigurationsResponse> ListBucketMetricsConfigurationsAsync(ListBucketMetricsConfigurationsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListBucketAnalyticsConfigurationsResponse> ListBucketAnalyticsConfigurationsAsync(ListBucketAnalyticsConfigurationsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListBucketsResponse ListBuckets()
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListBucketInventoryConfigurationsResponse> ListBucketInventoryConfigurationsAsync(ListBucketInventoryConfigurationsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListBucketsResponse ListBuckets(ListBucketsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListBucketMetricsConfigurationsResponse> ListBucketMetricsConfigurationsAsync(ListBucketMetricsConfigurationsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListBucketsResponse> ListBucketsAsync(CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListBucketsResponse> ListBucketsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListBucketsResponse> ListBucketsAsync(ListBucketsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListBucketsResponse> ListBucketsAsync(ListBucketsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<ListDirectoryBucketsResponse> ListDirectoryBucketsAsync(ListDirectoryBucketsRequest request,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public ListMultipartUploadsResponse ListMultipartUploads(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListMultipartUploadsResponse> ListMultipartUploadsAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListMultipartUploadsResponse ListMultipartUploads(string bucketName, string prefix)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListMultipartUploadsResponse> ListMultipartUploadsAsync(string bucketName, string prefix, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListMultipartUploadsResponse ListMultipartUploads(ListMultipartUploadsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListMultipartUploadsResponse> ListMultipartUploadsAsync(ListMultipartUploadsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListMultipartUploadsResponse> ListMultipartUploadsAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListObjectsResponse> ListObjectsAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListMultipartUploadsResponse> ListMultipartUploadsAsync(string bucketName, string prefix, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListObjectsResponse> ListObjectsAsync(string bucketName, string prefix, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListMultipartUploadsResponse> ListMultipartUploadsAsync(ListMultipartUploadsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListObjectsResponse> ListObjectsAsync(ListObjectsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListObjectsResponse ListObjects(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListObjectsV2Response> ListObjectsV2Async(ListObjectsV2Request request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListObjectsResponse ListObjects(string bucketName, string prefix)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListPartsResponse> ListPartsAsync(string bucketName, string key, string uploadId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListObjectsResponse ListObjects(ListObjectsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListPartsResponse> ListPartsAsync(ListPartsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListObjectsResponse> ListObjectsAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListVersionsResponse> ListVersionsAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListObjectsResponse> ListObjectsAsync(string bucketName, string prefix, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListVersionsResponse> ListVersionsAsync(string bucketName, string prefix, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListObjectsResponse> ListObjectsAsync(ListObjectsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListVersionsResponse> ListVersionsAsync(ListVersionsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListObjectsV2Response ListObjectsV2(ListObjectsV2Request request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutACLResponse> PutACLAsync(PutACLRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListObjectsV2Response> ListObjectsV2Async(ListObjectsV2Request request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketResponse> PutBucketAsync(string bucketName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListPartsResponse ListParts(string bucketName, string key, string uploadId)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketResponse> PutBucketAsync(PutBucketRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListPartsResponse ListParts(ListPartsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketAccelerateConfigurationResponse> PutBucketAccelerateConfigurationAsync(PutBucketAccelerateConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListPartsResponse> ListPartsAsync(string bucketName, string key, string uploadId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketAclResponse> PutBucketAclAsync(PutBucketAclRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListPartsResponse> ListPartsAsync(ListPartsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketAnalyticsConfigurationResponse> PutBucketAnalyticsConfigurationAsync(PutBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListVersionsResponse ListVersions(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketEncryptionResponse> PutBucketEncryptionAsync(PutBucketEncryptionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListVersionsResponse ListVersions(string bucketName, string prefix)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketInventoryConfigurationResponse> PutBucketInventoryConfigurationAsync(PutBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ListVersionsResponse ListVersions(ListVersionsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketLoggingResponse> PutBucketLoggingAsync(PutBucketLoggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListVersionsResponse> ListVersionsAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketMetricsConfigurationResponse> PutBucketMetricsConfigurationAsync(PutBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ListVersionsResponse> ListVersionsAsync(string bucketName, string prefix, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListVersionsResponse> ListVersionsAsync(ListVersionsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutACLResponse PutACL(PutACLRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutACLResponse> PutACLAsync(PutACLRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketResponse PutBucket(string bucketName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketResponse PutBucket(PutBucketRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketResponse> PutBucketAsync(string bucketName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketResponse> PutBucketAsync(PutBucketRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketAccelerateConfigurationResponse PutBucketAccelerateConfiguration(PutBucketAccelerateConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketAccelerateConfigurationResponse> PutBucketAccelerateConfigurationAsync(PutBucketAccelerateConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketAclResponse> PutBucketAclAsync(PutBucketAclRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
-
-    public PutBucketAnalyticsConfigurationResponse PutBucketAnalyticsConfiguration(PutBucketAnalyticsConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketAnalyticsConfigurationResponse> PutBucketAnalyticsConfigurationAsync(PutBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketEncryptionResponse PutBucketEncryption(PutBucketEncryptionRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketEncryptionResponse> PutBucketEncryptionAsync(PutBucketEncryptionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketInventoryConfigurationResponse PutBucketInventoryConfiguration(PutBucketInventoryConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketInventoryConfigurationResponse> PutBucketInventoryConfigurationAsync(PutBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketLoggingResponse PutBucketLogging(PutBucketLoggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketLoggingResponse> PutBucketLoggingAsync(PutBucketLoggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketMetricsConfigurationResponse PutBucketMetricsConfiguration(PutBucketMetricsConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketMetricsConfigurationResponse> PutBucketMetricsConfigurationAsync(PutBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketNotificationResponse PutBucketNotification(PutBucketNotificationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketNotificationResponse> PutBucketNotificationAsync(PutBucketNotificationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketOwnershipControlsResponse PutBucketOwnershipControls(PutBucketOwnershipControlsRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketNotificationResponse> PutBucketNotificationAsync(PutBucketNotificationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<PutBucketOwnershipControlsResponse> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request,
-        CancellationToken cancellationToken = new CancellationToken())
-    {
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
-    }
 
-    public PutBucketPolicyResponse PutBucketPolicy(string bucketName, string policy)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketPolicyResponse> PutBucketPolicyAsync(string bucketName, string policy, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketPolicyResponse PutBucketPolicy(string bucketName, string policy, string contentMD5)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketPolicyResponse> PutBucketPolicyAsync(string bucketName, string policy, string contentMD5, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketPolicyResponse PutBucketPolicy(PutBucketPolicyRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketPolicyResponse> PutBucketPolicyAsync(PutBucketPolicyRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketPolicyResponse> PutBucketPolicyAsync(string bucketName, string policy, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketReplicationResponse> PutBucketReplicationAsync(PutBucketReplicationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketPolicyResponse> PutBucketPolicyAsync(string bucketName, string policy, string contentMD5, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketRequestPaymentResponse> PutBucketRequestPaymentAsync(string bucketName, RequestPaymentConfiguration requestPaymentConfiguration, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketPolicyResponse> PutBucketPolicyAsync(PutBucketPolicyRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketRequestPaymentResponse> PutBucketRequestPaymentAsync(PutBucketRequestPaymentRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketReplicationResponse PutBucketReplication(PutBucketReplicationRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketTaggingResponse> PutBucketTaggingAsync(string bucketName, List<Tag> tagSet, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketReplicationResponse> PutBucketReplicationAsync(PutBucketReplicationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketTaggingResponse> PutBucketTaggingAsync(PutBucketTaggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketRequestPaymentResponse PutBucketRequestPayment(string bucketName, RequestPaymentConfiguration requestPaymentConfiguration)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketVersioningResponse> PutBucketVersioningAsync(PutBucketVersioningRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketRequestPaymentResponse PutBucketRequestPayment(PutBucketRequestPaymentRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketWebsiteResponse> PutBucketWebsiteAsync(string bucketName, WebsiteConfiguration websiteConfiguration, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketRequestPaymentResponse> PutBucketRequestPaymentAsync(string bucketName, RequestPaymentConfiguration requestPaymentConfiguration, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutBucketWebsiteResponse> PutBucketWebsiteAsync(PutBucketWebsiteRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketRequestPaymentResponse> PutBucketRequestPaymentAsync(PutBucketRequestPaymentRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutCORSConfigurationResponse> PutCORSConfigurationAsync(string bucketName, CORSConfiguration configuration, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketTaggingResponse PutBucketTagging(string bucketName, List<Tag> tagSet)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutCORSConfigurationResponse> PutCORSConfigurationAsync(PutCORSConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketTaggingResponse PutBucketTagging(PutBucketTaggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutLifecycleConfigurationResponse> PutLifecycleConfigurationAsync(string bucketName, LifecycleConfiguration configuration, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketTaggingResponse> PutBucketTaggingAsync(string bucketName, List<Tag> tagSet, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutLifecycleConfigurationResponse> PutLifecycleConfigurationAsync(PutLifecycleConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketTaggingResponse> PutBucketTaggingAsync(PutBucketTaggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutObjectTaggingResponse> PutObjectTaggingAsync(PutObjectTaggingRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public PutBucketVersioningResponse PutBucketVersioning(PutBucketVersioningRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PutPublicAccessBlockResponse> PutPublicAccessBlockAsync(PutPublicAccessBlockRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PutBucketVersioningResponse> PutBucketVersioningAsync(PutBucketVersioningRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketWebsiteResponse PutBucketWebsite(string bucketName, WebsiteConfiguration websiteConfiguration)
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutBucketWebsiteResponse PutBucketWebsite(PutBucketWebsiteRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketWebsiteResponse> PutBucketWebsiteAsync(string bucketName, WebsiteConfiguration websiteConfiguration, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutBucketWebsiteResponse> PutBucketWebsiteAsync(PutBucketWebsiteRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutCORSConfigurationResponse PutCORSConfiguration(string bucketName, CORSConfiguration configuration)
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutCORSConfigurationResponse PutCORSConfiguration(PutCORSConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutCORSConfigurationResponse> PutCORSConfigurationAsync(string bucketName, CORSConfiguration configuration, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutCORSConfigurationResponse> PutCORSConfigurationAsync(PutCORSConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutLifecycleConfigurationResponse PutLifecycleConfiguration(string bucketName, LifecycleConfiguration configuration)
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutLifecycleConfigurationResponse PutLifecycleConfiguration(PutLifecycleConfigurationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutLifecycleConfigurationResponse> PutLifecycleConfigurationAsync(string bucketName, LifecycleConfiguration configuration, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutLifecycleConfigurationResponse> PutLifecycleConfigurationAsync(PutLifecycleConfigurationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutObjectResponse PutObject(PutObjectRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutObjectTaggingResponse PutObjectTagging(PutObjectTaggingRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutObjectTaggingResponse> PutObjectTaggingAsync(PutObjectTaggingRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PutPublicAccessBlockResponse PutPublicAccessBlock(PutPublicAccessBlockRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PutPublicAccessBlockResponse> PutPublicAccessBlockAsync(PutPublicAccessBlockRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public RestoreObjectResponse RestoreObject(string bucketName, string key)
-    {
-        throw new NotImplementedException();
-    }
-
-    public RestoreObjectResponse RestoreObject(string bucketName, string key, int days)
-    {
-        throw new NotImplementedException();
-    }
-
-    public RestoreObjectResponse RestoreObject(string bucketName, string key, string versionId)
-    {
-        throw new NotImplementedException();
-    }
-
-    public RestoreObjectResponse RestoreObject(string bucketName, string key, string versionId, int days)
-    {
-        throw new NotImplementedException();
-    }
-
-    public RestoreObjectResponse RestoreObject(RestoreObjectRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, int? days,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, int days, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, string versionId, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, string versionId, int? days,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
+    public Task<RestoreObjectResponse> RestoreObjectAsync(RestoreObjectRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<RestoreObjectResponse> RestoreObjectAsync(string bucketName, string key, string versionId, int days, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<RestoreObjectResponse> RestoreObjectAsync(RestoreObjectRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public SelectObjectContentResponse SelectObjectContent(SelectObjectContentRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SelectObjectContentResponse> SelectObjectContentAsync(SelectObjectContentRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public UploadPartResponse UploadPart(UploadPartRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<UploadPartResponse> UploadPartAsync(UploadPartRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<SelectObjectContentResponse> SelectObjectContentAsync(SelectObjectContentRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<UploadPartResponse> UploadPartAsync(UploadPartRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public Task<WriteGetObjectResponseResponse> WriteGetObjectResponseAsync(WriteGetObjectResponseRequest request,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
     public Endpoint DetermineServiceOperationEndpoint(AmazonWebServiceRequest request) => throw new NotImplementedException();
 
-    public WriteGetObjectResponseResponse WriteGetObjectResponse(WriteGetObjectResponseRequest request) =>
-        throw new NotImplementedException();
-
-    public DeleteBucketIntelligentTieringConfigurationResponse DeleteBucketIntelligentTieringConfiguration(DeleteBucketIntelligentTieringConfigurationRequest request) => throw new NotImplementedException();
-
     public Task<DeleteBucketIntelligentTieringConfigurationResponse> DeleteBucketIntelligentTieringConfigurationAsync(DeleteBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-
-    public GetBucketIntelligentTieringConfigurationResponse GetBucketIntelligentTieringConfiguration(GetBucketIntelligentTieringConfigurationRequest request) => throw new NotImplementedException();
-
     public Task<GetBucketIntelligentTieringConfigurationResponse> GetBucketIntelligentTieringConfigurationAsync(GetBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-
-    public ListBucketIntelligentTieringConfigurationsResponse ListBucketIntelligentTieringConfigurations(ListBucketIntelligentTieringConfigurationsRequest request) => throw new NotImplementedException();
-
     public Task<ListBucketIntelligentTieringConfigurationsResponse> ListBucketIntelligentTieringConfigurationsAsync(ListBucketIntelligentTieringConfigurationsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-
-    public PutBucketIntelligentTieringConfigurationResponse PutBucketIntelligentTieringConfiguration(PutBucketIntelligentTieringConfigurationRequest request) => throw new NotImplementedException();
-
     public Task<PutBucketIntelligentTieringConfigurationResponse> PutBucketIntelligentTieringConfigurationAsync(PutBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public GetObjectAttributesResponse GetObjectAttributes(GetObjectAttributesRequest request) => throw new NotImplementedException();
     public Task<GetObjectAttributesResponse> GetObjectAttributesAsync(GetObjectAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public IS3PaginatorFactory Paginators { get; }

--- a/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSnsClient.cs
@@ -17,7 +17,7 @@ class MockSnsClient : IAmazonSimpleNotificationService
 {
     public ConcurrentQueue<string> UnsubscribeRequests = [];
 
-    public Task<UnsubscribeResponse> UnsubscribeAsync(string subscriptionArn, CancellationToken cancellationToken = new CancellationToken())
+    public Task<UnsubscribeResponse> UnsubscribeAsync(string subscriptionArn, CancellationToken cancellationToken = default)
     {
         UnsubscribeRequests.Enqueue(subscriptionArn);
         return Task.FromResult(new UnsubscribeResponse());
@@ -39,7 +39,7 @@ class MockSnsClient : IAmazonSimpleNotificationService
 
     public ConcurrentQueue<string> CreateTopicRequests { get; } = [];
 
-    public Task<CreateTopicResponse> CreateTopicAsync(string name, CancellationToken cancellationToken = new CancellationToken())
+    public Task<CreateTopicResponse> CreateTopicAsync(string name, CancellationToken cancellationToken = default)
     {
         CreateTopicRequests.Enqueue(name);
         return Task.FromResult(CreateTopicResponse(name));
@@ -47,7 +47,7 @@ class MockSnsClient : IAmazonSimpleNotificationService
 
     public ConcurrentQueue<PublishRequest> PublishedEvents { get; } = [];
 
-    public Task<PublishResponse> PublishAsync(PublishRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<PublishResponse> PublishAsync(PublishRequest request, CancellationToken cancellationToken = default)
     {
         PublishedEvents.Enqueue(request);
         return Task.FromResult(new PublishResponse());
@@ -60,7 +60,7 @@ class MockSnsClient : IAmazonSimpleNotificationService
 
     public ConcurrentQueue<string> ListSubscriptionsByTopicRequests { get; } = [];
 
-    public Task<ListSubscriptionsByTopicResponse> ListSubscriptionsByTopicAsync(string topicArn, string nextToken, CancellationToken cancellationToken = new CancellationToken())
+    public Task<ListSubscriptionsByTopicResponse> ListSubscriptionsByTopicAsync(string topicArn, string nextToken, CancellationToken cancellationToken = default)
     {
         ListSubscriptionsByTopicRequests.Enqueue(topicArn);
         return Task.FromResult(ListSubscriptionsByTopicResponse(topicArn));
@@ -70,7 +70,7 @@ class MockSnsClient : IAmazonSimpleNotificationService
 
     public Func<SubscribeRequest, SubscribeResponse> SubscribeResponse = req => new SubscribeResponse { SubscriptionArn = "arn:fakeQueue" };
 
-    public Task<SubscribeResponse> SubscribeAsync(SubscribeRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<SubscribeResponse> SubscribeAsync(SubscribeRequest request, CancellationToken cancellationToken = default)
     {
         SubscribeRequestsSent.Enqueue(request);
         return Task.FromResult(SubscribeResponse(request));
@@ -92,30 +92,15 @@ class MockSnsClient : IAmazonSimpleNotificationService
 
     #region NotImplemented
 
-    public TagResourceResponse TagResource(TagResourceRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public TagResourceResponse TagResource(TagResourceRequest request) => throw new NotImplementedException();
 
-    public Task<TagResourceResponse> TagResourceAsync(TagResourceRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<TagResourceResponse> TagResourceAsync(TagResourceRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<SetSubscriptionAttributesResponse> SetSubscriptionAttributesAsync(SetSubscriptionAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<SetSubscriptionAttributesResponse> SetSubscriptionAttributesAsync(SetSubscriptionAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<string> SubscribeQueueAsync(string topicArn, ICoreAmazonSQS sqsClient, string sqsQueueUrl)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<string> SubscribeQueueAsync(string topicArn, ICoreAmazonSQS sqsClient, string sqsQueueUrl) => throw new NotImplementedException();
 
-    public Task<PublishResponse> PublishAsync(string topicArn, string message, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PublishResponse> PublishAsync(string topicArn, string message, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public IClientConfig Config { get; }
 
@@ -123,547 +108,113 @@ class MockSnsClient : IAmazonSimpleNotificationService
 
     public ISimpleNotificationServicePaginatorFactory Paginators => throw new NotImplementedException();
 
-    public string SubscribeQueue(string topicArn, ICoreAmazonSQS sqsClient, string sqsQueueUrl)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IDictionary<string, string> SubscribeQueueToTopics(IList<string> topicArns, ICoreAmazonSQS sqsClient, string sqsQueueUrl)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<IDictionary<string, string>> SubscribeQueueToTopicsAsync(IList<string> topicArns, ICoreAmazonSQS sqsClient, string sqsQueueUrl)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Topic FindTopic(string topicName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void AuthorizeS3ToPublish(string topicArn, string bucket)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task AuthorizeS3ToPublishAsync(string topicArn, string bucket)
-    {
-        throw new NotImplementedException();
-    }
-
-    public AddPermissionResponse AddPermission(string topicArn, string label, List<string> awsAccountId, List<string> actionName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public AddPermissionResponse AddPermission(AddPermissionRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<AddPermissionResponse> AddPermissionAsync(string topicArn, string label, List<string> awsAccountId, List<string> actionName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<AddPermissionResponse> AddPermissionAsync(AddPermissionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CheckIfPhoneNumberIsOptedOutResponse CheckIfPhoneNumberIsOptedOut(CheckIfPhoneNumberIsOptedOutRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CheckIfPhoneNumberIsOptedOutResponse> CheckIfPhoneNumberIsOptedOutAsync(CheckIfPhoneNumberIsOptedOutRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ConfirmSubscriptionResponse ConfirmSubscription(string topicArn, string token, string authenticateOnUnsubscribe)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ConfirmSubscriptionResponse ConfirmSubscription(string topicArn, string token)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ConfirmSubscriptionResponse ConfirmSubscription(ConfirmSubscriptionRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ConfirmSubscriptionResponse> ConfirmSubscriptionAsync(string topicArn, string token, string authenticateOnUnsubscribe, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ConfirmSubscriptionResponse> ConfirmSubscriptionAsync(string topicArn, string token, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ConfirmSubscriptionResponse> ConfirmSubscriptionAsync(ConfirmSubscriptionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CreatePlatformApplicationResponse CreatePlatformApplication(CreatePlatformApplicationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CreatePlatformApplicationResponse> CreatePlatformApplicationAsync(CreatePlatformApplicationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CreatePlatformEndpointResponse CreatePlatformEndpoint(CreatePlatformEndpointRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CreatePlatformEndpointResponse> CreatePlatformEndpointAsync(CreatePlatformEndpointRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CreateTopicResponse CreateTopic(string name)
-    {
-        throw new NotImplementedException();
-    }
-
-    public CreateTopicResponse CreateTopic(CreateTopicRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CreateTopicResponse> CreateTopicAsync(CreateTopicRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteEndpointResponse DeleteEndpoint(DeleteEndpointRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteEndpointResponse> DeleteEndpointAsync(DeleteEndpointRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeletePlatformApplicationResponse DeletePlatformApplication(DeletePlatformApplicationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeletePlatformApplicationResponse> DeletePlatformApplicationAsync(DeletePlatformApplicationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteTopicResponse DeleteTopic(string topicArn)
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteTopicResponse DeleteTopic(DeleteTopicRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteTopicResponse> DeleteTopicAsync(string topicArn, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteTopicResponse> DeleteTopicAsync(DeleteTopicRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetEndpointAttributesResponse GetEndpointAttributes(GetEndpointAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetEndpointAttributesResponse> GetEndpointAttributesAsync(GetEndpointAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetPlatformApplicationAttributesResponse GetPlatformApplicationAttributes(GetPlatformApplicationAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetPlatformApplicationAttributesResponse> GetPlatformApplicationAttributesAsync(GetPlatformApplicationAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetSMSAttributesResponse GetSMSAttributes(GetSMSAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetSMSAttributesResponse> GetSMSAttributesAsync(GetSMSAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetSubscriptionAttributesResponse GetSubscriptionAttributes(string subscriptionArn)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetSubscriptionAttributesResponse GetSubscriptionAttributes(GetSubscriptionAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetSubscriptionAttributesResponse> GetSubscriptionAttributesAsync(string subscriptionArn, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetSubscriptionAttributesResponse> GetSubscriptionAttributesAsync(GetSubscriptionAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetTopicAttributesResponse GetTopicAttributes(string topicArn)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetTopicAttributesResponse GetTopicAttributes(GetTopicAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetTopicAttributesResponse> GetTopicAttributesAsync(string topicArn, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetTopicAttributesResponse> GetTopicAttributesAsync(GetTopicAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListEndpointsByPlatformApplicationResponse ListEndpointsByPlatformApplication(ListEndpointsByPlatformApplicationRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListEndpointsByPlatformApplicationResponse> ListEndpointsByPlatformApplicationAsync(ListEndpointsByPlatformApplicationRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListPhoneNumbersOptedOutResponse ListPhoneNumbersOptedOut(ListPhoneNumbersOptedOutRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListPhoneNumbersOptedOutResponse> ListPhoneNumbersOptedOutAsync(ListPhoneNumbersOptedOutRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListPlatformApplicationsResponse ListPlatformApplications()
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListPlatformApplicationsResponse ListPlatformApplications(ListPlatformApplicationsRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListPlatformApplicationsResponse> ListPlatformApplicationsAsync(CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListPlatformApplicationsResponse> ListPlatformApplicationsAsync(ListPlatformApplicationsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListSubscriptionsResponse ListSubscriptions()
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListSubscriptionsResponse ListSubscriptions(string nextToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListSubscriptionsResponse ListSubscriptions(ListSubscriptionsRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListSubscriptionsResponse> ListSubscriptionsAsync(CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListSubscriptionsResponse> ListSubscriptionsAsync(string nextToken, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListSubscriptionsResponse> ListSubscriptionsAsync(ListSubscriptionsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListSubscriptionsByTopicResponse ListSubscriptionsByTopic(string topicArn, string nextToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListSubscriptionsByTopicResponse ListSubscriptionsByTopic(string topicArn)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListSubscriptionsByTopicResponse ListSubscriptionsByTopic(ListSubscriptionsByTopicRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListSubscriptionsByTopicResponse> ListSubscriptionsByTopicAsync(string topicArn, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListSubscriptionsByTopicResponse> ListSubscriptionsByTopicAsync(ListSubscriptionsByTopicRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListTagsForResourceResponse ListTagsForResource(ListTagsForResourceRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListTagsForResourceResponse> ListTagsForResourceAsync(ListTagsForResourceRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListTopicsResponse ListTopics()
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListTopicsResponse ListTopics(string nextToken)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListTopicsResponse ListTopics(ListTopicsRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListTopicsResponse> ListTopicsAsync(CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListTopicsResponse> ListTopicsAsync(string nextToken, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListTopicsResponse> ListTopicsAsync(ListTopicsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public OptInPhoneNumberResponse OptInPhoneNumber(OptInPhoneNumberRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<OptInPhoneNumberResponse> OptInPhoneNumberAsync(OptInPhoneNumberRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PublishResponse Publish(string topicArn, string message)
-    {
-        throw new NotImplementedException();
-    }
-
-    public PublishResponse Publish(string topicArn, string message, string subject)
-    {
-        throw new NotImplementedException();
-    }
-
-    public PublishResponse Publish(PublishRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PublishResponse> PublishAsync(string topicArn, string message, string subject, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public RemovePermissionResponse RemovePermission(string topicArn, string label)
-    {
-        throw new NotImplementedException();
-    }
-
-    public RemovePermissionResponse RemovePermission(RemovePermissionRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<RemovePermissionResponse> RemovePermissionAsync(string topicArn, string label, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<RemovePermissionResponse> RemovePermissionAsync(RemovePermissionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public SetEndpointAttributesResponse SetEndpointAttributes(SetEndpointAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SetEndpointAttributesResponse> SetEndpointAttributesAsync(SetEndpointAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public SetPlatformApplicationAttributesResponse SetPlatformApplicationAttributes(SetPlatformApplicationAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SetPlatformApplicationAttributesResponse> SetPlatformApplicationAttributesAsync(SetPlatformApplicationAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public SetSMSAttributesResponse SetSMSAttributes(SetSMSAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SetSMSAttributesResponse> SetSMSAttributesAsync(SetSMSAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public SetSubscriptionAttributesResponse SetSubscriptionAttributes(string subscriptionArn, string attributeName, string attributeValue)
-    {
-        throw new NotImplementedException();
-    }
-
-    public SetSubscriptionAttributesResponse SetSubscriptionAttributes(SetSubscriptionAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SetSubscriptionAttributesResponse> SetSubscriptionAttributesAsync(string subscriptionArn, string attributeName, string attributeValue, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public SetTopicAttributesResponse SetTopicAttributes(string topicArn, string attributeName, string attributeValue)
-    {
-        throw new NotImplementedException();
-    }
-
-    public SetTopicAttributesResponse SetTopicAttributes(SetTopicAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SetTopicAttributesResponse> SetTopicAttributesAsync(string topicArn, string attributeName, string attributeValue, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SetTopicAttributesResponse> SetTopicAttributesAsync(SetTopicAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public SubscribeResponse Subscribe(string topicArn, string protocol, string endpoint)
-    {
-        throw new NotImplementedException();
-    }
-
-    public SubscribeResponse Subscribe(SubscribeRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<SubscribeResponse> SubscribeAsync(string topicArn, string protocol, string endpoint, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public UnsubscribeResponse Unsubscribe(string subscriptionArn)
-    {
-        throw new NotImplementedException();
-    }
-
-    public UnsubscribeResponse Unsubscribe(UnsubscribeRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<UnsubscribeResponse> UnsubscribeAsync(UnsubscribeRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public UntagResourceResponse UntagResource(UntagResourceRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<UntagResourceResponse> UntagResourceAsync(UntagResourceRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CreateSMSSandboxPhoneNumberResponse CreateSMSSandboxPhoneNumber(CreateSMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
+    public string SubscribeQueue(string topicArn, ICoreAmazonSQS sqsClient, string sqsQueueUrl) => throw new NotImplementedException();
+
+    public IDictionary<string, string> SubscribeQueueToTopics(IList<string> topicArns, ICoreAmazonSQS sqsClient, string sqsQueueUrl) => throw new NotImplementedException();
+
+    public Task<IDictionary<string, string>> SubscribeQueueToTopicsAsync(IList<string> topicArns, ICoreAmazonSQS sqsClient, string sqsQueueUrl) => throw new NotImplementedException();
+
+    public Task AuthorizeS3ToPublishAsync(string topicArn, string bucket) => throw new NotImplementedException();
+
+    public Task<AddPermissionResponse> AddPermissionAsync(string topicArn, string label, List<string> awsAccountId, List<string> actionName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<AddPermissionResponse> AddPermissionAsync(AddPermissionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<CheckIfPhoneNumberIsOptedOutResponse> CheckIfPhoneNumberIsOptedOutAsync(CheckIfPhoneNumberIsOptedOutRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ConfirmSubscriptionResponse> ConfirmSubscriptionAsync(string topicArn, string token, string authenticateOnUnsubscribe, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ConfirmSubscriptionResponse> ConfirmSubscriptionAsync(string topicArn, string token, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ConfirmSubscriptionResponse> ConfirmSubscriptionAsync(ConfirmSubscriptionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<CreatePlatformApplicationResponse> CreatePlatformApplicationAsync(CreatePlatformApplicationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<CreatePlatformEndpointResponse> CreatePlatformEndpointAsync(CreatePlatformEndpointRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<CreateTopicResponse> CreateTopicAsync(CreateTopicRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<DeleteEndpointResponse> DeleteEndpointAsync(DeleteEndpointRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<DeletePlatformApplicationResponse> DeletePlatformApplicationAsync(DeletePlatformApplicationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<DeleteTopicResponse> DeleteTopicAsync(string topicArn, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<DeleteTopicResponse> DeleteTopicAsync(DeleteTopicRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<GetEndpointAttributesResponse> GetEndpointAttributesAsync(GetEndpointAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<GetPlatformApplicationAttributesResponse> GetPlatformApplicationAttributesAsync(GetPlatformApplicationAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<GetSMSAttributesResponse> GetSMSAttributesAsync(GetSMSAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<GetSubscriptionAttributesResponse> GetSubscriptionAttributesAsync(string subscriptionArn, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<GetSubscriptionAttributesResponse> GetSubscriptionAttributesAsync(GetSubscriptionAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<GetTopicAttributesResponse> GetTopicAttributesAsync(string topicArn, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<GetTopicAttributesResponse> GetTopicAttributesAsync(GetTopicAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListEndpointsByPlatformApplicationResponse> ListEndpointsByPlatformApplicationAsync(ListEndpointsByPlatformApplicationRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListPhoneNumbersOptedOutResponse> ListPhoneNumbersOptedOutAsync(ListPhoneNumbersOptedOutRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListPlatformApplicationsResponse> ListPlatformApplicationsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListPlatformApplicationsResponse> ListPlatformApplicationsAsync(ListPlatformApplicationsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListSubscriptionsResponse> ListSubscriptionsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListSubscriptionsResponse> ListSubscriptionsAsync(string nextToken, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListSubscriptionsResponse> ListSubscriptionsAsync(ListSubscriptionsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListSubscriptionsByTopicResponse> ListSubscriptionsByTopicAsync(string topicArn, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListSubscriptionsByTopicResponse> ListSubscriptionsByTopicAsync(ListSubscriptionsByTopicRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListTagsForResourceResponse> ListTagsForResourceAsync(ListTagsForResourceRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListTopicsResponse> ListTopicsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListTopicsResponse> ListTopicsAsync(string nextToken, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<ListTopicsResponse> ListTopicsAsync(ListTopicsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<OptInPhoneNumberResponse> OptInPhoneNumberAsync(OptInPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<PublishResponse> PublishAsync(string topicArn, string message, string subject, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<RemovePermissionResponse> RemovePermissionAsync(string topicArn, string label, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<RemovePermissionResponse> RemovePermissionAsync(RemovePermissionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<SetEndpointAttributesResponse> SetEndpointAttributesAsync(SetEndpointAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<SetPlatformApplicationAttributesResponse> SetPlatformApplicationAttributesAsync(SetPlatformApplicationAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<SetSMSAttributesResponse> SetSMSAttributesAsync(SetSMSAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<SetSubscriptionAttributesResponse> SetSubscriptionAttributesAsync(string subscriptionArn, string attributeName, string attributeValue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<SetTopicAttributesResponse> SetTopicAttributesAsync(string topicArn, string attributeName, string attributeValue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<SetTopicAttributesResponse> SetTopicAttributesAsync(SetTopicAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<SubscribeResponse> SubscribeAsync(string topicArn, string protocol, string endpoint, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<UnsubscribeResponse> UnsubscribeAsync(UnsubscribeRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+    public Task<UntagResourceResponse> UntagResourceAsync(UntagResourceRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
     public Task<CreateSMSSandboxPhoneNumberResponse> CreateSMSSandboxPhoneNumberAsync(CreateSMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public DeleteSMSSandboxPhoneNumberResponse DeleteSMSSandboxPhoneNumber(DeleteSMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
     public Task<DeleteSMSSandboxPhoneNumberResponse> DeleteSMSSandboxPhoneNumberAsync(DeleteSMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public GetSMSSandboxAccountStatusResponse GetSMSSandboxAccountStatus(GetSMSSandboxAccountStatusRequest request) => throw new NotImplementedException();
     public Task<GetSMSSandboxAccountStatusResponse> GetSMSSandboxAccountStatusAsync(GetSMSSandboxAccountStatusRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public ListOriginationNumbersResponse ListOriginationNumbers(ListOriginationNumbersRequest request) => throw new NotImplementedException();
     public Task<ListOriginationNumbersResponse> ListOriginationNumbersAsync(ListOriginationNumbersRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public ListSMSSandboxPhoneNumbersResponse ListSMSSandboxPhoneNumbers(ListSMSSandboxPhoneNumbersRequest request) => throw new NotImplementedException();
     public Task<ListSMSSandboxPhoneNumbersResponse> ListSMSSandboxPhoneNumbersAsync(ListSMSSandboxPhoneNumbersRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public VerifySMSSandboxPhoneNumberResponse VerifySMSSandboxPhoneNumber(VerifySMSSandboxPhoneNumberRequest request) => throw new NotImplementedException();
     public Task<VerifySMSSandboxPhoneNumberResponse> VerifySMSSandboxPhoneNumberAsync(VerifySMSSandboxPhoneNumberRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public PublishBatchResponse PublishBatch(PublishBatchRequest request) => throw new NotImplementedException();
-    public GetDataProtectionPolicyResponse GetDataProtectionPolicy(GetDataProtectionPolicyRequest request) => throw new NotImplementedException();
     public Task<GetDataProtectionPolicyResponse> GetDataProtectionPolicyAsync(GetDataProtectionPolicyRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-    public PutDataProtectionPolicyResponse PutDataProtectionPolicy(PutDataProtectionPolicyRequest request) => throw new NotImplementedException();
     public Task<PutDataProtectionPolicyResponse> PutDataProtectionPolicyAsync(PutDataProtectionPolicyRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     #endregion

--- a/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
@@ -190,6 +190,10 @@ class MockSqsClient : IAmazonSQS
 
     #region NotImplemented
 
+    public Task<ChangeMessageVisibilityResponse> ChangeMessageVisibilityAsync(string queueUrl, string receiptHandle, int? visibilityTimeout,
+        CancellationToken cancellationToken = new CancellationToken()) =>
+        throw new NotImplementedException();
+
     public Dictionary<string, string> GetAttributes(string queueUrl)
     {
         throw new NotImplementedException();

--- a/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
@@ -18,7 +18,7 @@ class MockSqsClient : IAmazonSQS
     };
     public ConcurrentQueue<string> QueueUrlRequestsSent { get; } = [];
 
-    public Task<GetQueueUrlResponse> GetQueueUrlAsync(string queueName, CancellationToken cancellationToken = new CancellationToken())
+    public Task<GetQueueUrlResponse> GetQueueUrlAsync(string queueName, CancellationToken cancellationToken = default)
     {
         QueueUrlRequestsSent.Enqueue(queueName);
         return Task.FromResult(new GetQueueUrlResponse { QueueUrl = queueName });
@@ -28,8 +28,7 @@ class MockSqsClient : IAmazonSQS
 
     public Func<SendMessageBatchRequest, SendMessageBatchResponse> BatchRequestResponse = req => new SendMessageBatchResponse();
 
-
-    public Task<SendMessageBatchResponse> SendMessageBatchAsync(SendMessageBatchRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<SendMessageBatchResponse> SendMessageBatchAsync(SendMessageBatchRequest request, CancellationToken cancellationToken = default)
     {
         BatchRequestsSent.Enqueue(request);
         return Task.FromResult(BatchRequestResponse(request));
@@ -39,7 +38,7 @@ class MockSqsClient : IAmazonSQS
 
     public Func<DeleteMessageBatchRequest, DeleteMessageBatchResponse> DeleteMessageBatchRequestResponse = req => new DeleteMessageBatchResponse();
 
-    public Task<DeleteMessageBatchResponse> DeleteMessageBatchAsync(DeleteMessageBatchRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<DeleteMessageBatchResponse> DeleteMessageBatchAsync(DeleteMessageBatchRequest request, CancellationToken cancellationToken = default)
     {
         DeleteMessageBatchRequestsSent.Enqueue(request);
         return Task.FromResult(DeleteMessageBatchRequestResponse(request));
@@ -49,7 +48,7 @@ class MockSqsClient : IAmazonSQS
 
     public Func<ChangeMessageVisibilityBatchRequest, ChangeMessageVisibilityBatchResponse> ChangeMessageVisibilityBatchRequestResponse = req => new ChangeMessageVisibilityBatchResponse();
 
-    public Task<ChangeMessageVisibilityBatchResponse> ChangeMessageVisibilityBatchAsync(ChangeMessageVisibilityBatchRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<ChangeMessageVisibilityBatchResponse> ChangeMessageVisibilityBatchAsync(ChangeMessageVisibilityBatchRequest request, CancellationToken cancellationToken = default)
     {
         ChangeMessageVisibilityBatchRequestsSent.Enqueue(request);
         return Task.FromResult(ChangeMessageVisibilityBatchRequestResponse(request));
@@ -59,13 +58,13 @@ class MockSqsClient : IAmazonSQS
 
     public Func<(string queueUrl, string receiptHandle), DeleteMessageResponse> DeleteMessageRequestResponse = req => new DeleteMessageResponse();
 
-    public Task<DeleteMessageResponse> DeleteMessageAsync(string queueUrl, string receiptHandle, CancellationToken cancellationToken = new CancellationToken())
+    public Task<DeleteMessageResponse> DeleteMessageAsync(string queueUrl, string receiptHandle, CancellationToken cancellationToken = default)
     {
         DeleteMessageRequestsSent.Enqueue((queueUrl, receiptHandle));
         return Task.FromResult(DeleteMessageRequestResponse((queueUrl, receiptHandle)));
     }
 
-    public Task<DeleteMessageResponse> DeleteMessageAsync(DeleteMessageRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<DeleteMessageResponse> DeleteMessageAsync(DeleteMessageRequest request, CancellationToken cancellationToken = default)
     {
         DeleteMessageRequestsSent.Enqueue((request.QueueUrl, request.ReceiptHandle));
         return Task.FromResult(DeleteMessageRequestResponse((request.QueueUrl, request.ReceiptHandle)));
@@ -75,7 +74,7 @@ class MockSqsClient : IAmazonSQS
     public Func<SendMessageRequest, SendMessageResponse> RequestResponse = req => new SendMessageResponse();
 
 
-    public Task<SendMessageResponse> SendMessageAsync(SendMessageRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<SendMessageResponse> SendMessageAsync(SendMessageRequest request, CancellationToken cancellationToken = default)
     {
         RequestsSent.Enqueue(request);
         return Task.FromResult(RequestResponse(request));
@@ -104,7 +103,7 @@ class MockSqsClient : IAmazonSQS
         }
     };
 
-    public Task<GetQueueAttributesResponse> GetQueueAttributesAsync(string queueUrl, List<string> attributeNames, CancellationToken cancellationToken = new CancellationToken())
+    public Task<GetQueueAttributesResponse> GetQueueAttributesAsync(string queueUrl, List<string> attributeNames, CancellationToken cancellationToken = default)
     {
         GetAttributeNamesRequestsSent.Enqueue((queueUrl, attributeNames));
         return Task.FromResult(GetAttributeNamesRequestsResponse(queueUrl, attributeNames));
@@ -113,7 +112,6 @@ class MockSqsClient : IAmazonSQS
     public ConcurrentQueue<(string queueUrl, Dictionary<string, string> attributes)> SetAttributesRequestsSent { get; } = [];
 
     public Dictionary<string, Queue<Dictionary<string, string>>> SetAttributesRequestsSentByUrl { get; } = [];
-
 
     public Task SetAttributesAsync(string queueUrl, Dictionary<string, string> attributes)
     {
@@ -135,8 +133,7 @@ class MockSqsClient : IAmazonSQS
         return Task.CompletedTask;
     }
 
-    public void EnableGetAttributeReturnsWhatWasSet()
-    {
+    public void EnableGetAttributeReturnsWhatWasSet() =>
         GetAttributeRequestsResponse = queueUrl =>
         {
             if (!SetAttributesRequestsSentByUrl.TryGetValue(queueUrl, out Queue<Dictionary<string, string>> queue))
@@ -156,7 +153,6 @@ class MockSqsClient : IAmazonSQS
             }
             return queue.Dequeue();
         };
-    }
 
     public ConcurrentQueue<ReceiveMessageRequest> ReceiveMessagesRequestsSent { get; } = [];
     public Func<ReceiveMessageRequest, CancellationToken, ReceiveMessageResponse> ReceiveMessagesRequestResponse = (req, token) =>
@@ -165,7 +161,7 @@ class MockSqsClient : IAmazonSQS
         return new ReceiveMessageResponse();
     };
 
-    public Task<ReceiveMessageResponse> ReceiveMessageAsync(ReceiveMessageRequest request, CancellationToken cancellationToken = new CancellationToken())
+    public Task<ReceiveMessageResponse> ReceiveMessageAsync(ReceiveMessageRequest request, CancellationToken cancellationToken = default)
     {
         ReceiveMessagesRequestsSent.Enqueue(request);
         return Task.FromResult(ReceiveMessagesRequestResponse(request, cancellationToken));
@@ -184,6 +180,8 @@ class MockSqsClient : IAmazonSQS
         return Task.FromResult(ChangeMessageVisibilityRequestResponse(request, cancellationToken));
     }
 
+    public Endpoint DetermineServiceOperationEndpoint(AmazonWebServiceRequest request) => new("https://sqs.us-east-1.amazonaws.com");
+
     public bool DisposeInvoked { get; private set; }
 
     public void Dispose() => DisposeInvoked = true;
@@ -191,354 +189,66 @@ class MockSqsClient : IAmazonSQS
     #region NotImplemented
 
     public Task<ChangeMessageVisibilityResponse> ChangeMessageVisibilityAsync(string queueUrl, string receiptHandle, int? visibilityTimeout,
-        CancellationToken cancellationToken = new CancellationToken()) =>
+        CancellationToken cancellationToken = default) =>
         throw new NotImplementedException();
 
-    public Dictionary<string, string> GetAttributes(string queueUrl)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void SetAttributes(string queueUrl, Dictionary<string, string> attributes)
-    {
-        throw new NotImplementedException();
-    }
-
-    public string AuthorizeS3ToSendMessage(string queueUrl, string bucket)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<string> AuthorizeS3ToSendMessageAsync(string queueUrl, string bucket)
-    {
-        throw new NotImplementedException();
-    }
-
-    public AddPermissionResponse AddPermission(string queueUrl, string label, List<string> awsAccountIds, List<string> actions)
-    {
-        throw new NotImplementedException();
-    }
-
-    public AddPermissionResponse AddPermission(AddPermissionRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<AddPermissionResponse> AddPermissionAsync(string queueUrl, string label, List<string> awsAccountIds, List<string> actions, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<AddPermissionResponse> AddPermissionAsync(AddPermissionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CancelMessageMoveTaskResponse CancelMessageMoveTask(CancelMessageMoveTaskRequest request) => throw new NotImplementedException();
-
-    public Task<CancelMessageMoveTaskResponse> CancelMessageMoveTaskAsync(CancelMessageMoveTaskRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
-
-    public ChangeMessageVisibilityResponse ChangeMessageVisibility(string queueUrl, string receiptHandle, int visibilityTimeout)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ChangeMessageVisibilityResponse ChangeMessageVisibility(ChangeMessageVisibilityRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ChangeMessageVisibilityResponse> ChangeMessageVisibilityAsync(string queueUrl, string receiptHandle, int visibilityTimeout, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ChangeMessageVisibilityBatchResponse ChangeMessageVisibilityBatch(string queueUrl, List<ChangeMessageVisibilityBatchRequestEntry> entries)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ChangeMessageVisibilityBatchResponse ChangeMessageVisibilityBatch(ChangeMessageVisibilityBatchRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ChangeMessageVisibilityBatchResponse> ChangeMessageVisibilityBatchAsync(string queueUrl, List<ChangeMessageVisibilityBatchRequestEntry> entries, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public CreateQueueResponse CreateQueue(string queueName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public CreateQueueResponse CreateQueue(CreateQueueRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CreateQueueResponse> CreateQueueAsync(string queueName, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<CreateQueueResponse> CreateQueueAsync(CreateQueueRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteMessageResponse DeleteMessage(string queueUrl, string receiptHandle)
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteMessageResponse DeleteMessage(DeleteMessageRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteMessageBatchResponse DeleteMessageBatch(string queueUrl, List<DeleteMessageBatchRequestEntry> entries)
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteMessageBatchResponse DeleteMessageBatch(DeleteMessageBatchRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteMessageBatchResponse> DeleteMessageBatchAsync(string queueUrl, List<DeleteMessageBatchRequestEntry> entries, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteQueueResponse DeleteQueue(string queueUrl)
-    {
-        throw new NotImplementedException();
-    }
-
-    public DeleteQueueResponse DeleteQueue(DeleteQueueRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteQueueResponse> DeleteQueueAsync(string queueUrl, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<DeleteQueueResponse> DeleteQueueAsync(DeleteQueueRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetQueueAttributesResponse GetQueueAttributes(string queueUrl, List<string> attributeNames)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetQueueAttributesResponse GetQueueAttributes(GetQueueAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetQueueAttributesResponse> GetQueueAttributesAsync(GetQueueAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetQueueUrlResponse GetQueueUrl(string queueName)
-    {
-        throw new NotImplementedException();
-    }
-
-    public GetQueueUrlResponse GetQueueUrl(GetQueueUrlRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<GetQueueUrlResponse> GetQueueUrlAsync(GetQueueUrlRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListDeadLetterSourceQueuesResponse ListDeadLetterSourceQueues(ListDeadLetterSourceQueuesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListDeadLetterSourceQueuesResponse> ListDeadLetterSourceQueuesAsync(ListDeadLetterSourceQueuesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListMessageMoveTasksResponse ListMessageMoveTasks(ListMessageMoveTasksRequest request) => throw new NotImplementedException();
-
-    public Task<ListMessageMoveTasksResponse> ListMessageMoveTasksAsync(ListMessageMoveTasksRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
-
-    public ListQueuesResponse ListQueues(string queueNamePrefix)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListQueuesResponse ListQueues(ListQueuesRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListQueuesResponse> ListQueuesAsync(string queueNamePrefix, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListQueuesResponse> ListQueuesAsync(ListQueuesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public ListQueueTagsResponse ListQueueTags(ListQueueTagsRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ListQueueTagsResponse> ListQueueTagsAsync(ListQueueTagsRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
-
-    public PurgeQueueResponse PurgeQueue(string queueUrl)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<string> AuthorizeS3ToSendMessageAsync(string queueUrl, string bucket) => throw new NotImplementedException();
 
-    public PurgeQueueResponse PurgeQueue(PurgeQueueRequest request)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<PurgeQueueResponse> PurgeQueueAsync(string queueUrl, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<AddPermissionResponse> AddPermissionAsync(string queueUrl, string label, List<string> awsAccountIds, List<string> actions, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<PurgeQueueResponse> PurgeQueueAsync(PurgeQueueRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<AddPermissionResponse> AddPermissionAsync(AddPermissionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ReceiveMessageResponse ReceiveMessage(string queueUrl)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<CancelMessageMoveTaskResponse> CancelMessageMoveTaskAsync(CancelMessageMoveTaskRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public ReceiveMessageResponse ReceiveMessage(ReceiveMessageRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ChangeMessageVisibilityBatchResponse> ChangeMessageVisibilityBatchAsync(string queueUrl, List<ChangeMessageVisibilityBatchRequestEntry> entries, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<ReceiveMessageResponse> ReceiveMessageAsync(string queueUrl, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<CreateQueueResponse> CreateQueueAsync(string queueName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
+    public Task<CreateQueueResponse> CreateQueueAsync(CreateQueueRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
+    public Task<DeleteMessageBatchResponse> DeleteMessageBatchAsync(string queueUrl, List<DeleteMessageBatchRequestEntry> entries, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public RemovePermissionResponse RemovePermission(string queueUrl, string label)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteQueueResponse> DeleteQueueAsync(string queueUrl, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public RemovePermissionResponse RemovePermission(RemovePermissionRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<DeleteQueueResponse> DeleteQueueAsync(DeleteQueueRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<RemovePermissionResponse> RemovePermissionAsync(string queueUrl, string label, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetQueueAttributesResponse> GetQueueAttributesAsync(GetQueueAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<RemovePermissionResponse> RemovePermissionAsync(RemovePermissionRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<GetQueueUrlResponse> GetQueueUrlAsync(GetQueueUrlRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public SendMessageResponse SendMessage(string queueUrl, string messageBody)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListDeadLetterSourceQueuesResponse> ListDeadLetterSourceQueuesAsync(ListDeadLetterSourceQueuesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public SendMessageResponse SendMessage(SendMessageRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListMessageMoveTasksResponse> ListMessageMoveTasksAsync(ListMessageMoveTasksRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<SendMessageResponse> SendMessageAsync(string queueUrl, string messageBody, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListQueuesResponse> ListQueuesAsync(string queueNamePrefix, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public SendMessageBatchResponse SendMessageBatch(string queueUrl, List<SendMessageBatchRequestEntry> entries)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListQueuesResponse> ListQueuesAsync(ListQueuesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public SendMessageBatchResponse SendMessageBatch(SendMessageBatchRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ListQueueTagsResponse> ListQueueTagsAsync(ListQueueTagsRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<SendMessageBatchResponse> SendMessageBatchAsync(string queueUrl, List<SendMessageBatchRequestEntry> entries, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PurgeQueueResponse> PurgeQueueAsync(string queueUrl, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public SetQueueAttributesResponse SetQueueAttributes(string queueUrl, Dictionary<string, string> attributes)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<PurgeQueueResponse> PurgeQueueAsync(PurgeQueueRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public SetQueueAttributesResponse SetQueueAttributes(SetQueueAttributesRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<ReceiveMessageResponse> ReceiveMessageAsync(string queueUrl, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(string queueUrl, Dictionary<string, string> attributes, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<RemovePermissionResponse> RemovePermissionAsync(string queueUrl, string label, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(SetQueueAttributesRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<RemovePermissionResponse> RemovePermissionAsync(RemovePermissionRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public StartMessageMoveTaskResponse StartMessageMoveTask(StartMessageMoveTaskRequest request) => throw new NotImplementedException();
+    public Task<SendMessageResponse> SendMessageAsync(string queueUrl, string messageBody, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<StartMessageMoveTaskResponse> StartMessageMoveTaskAsync(StartMessageMoveTaskRequest request, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+    public Task<SendMessageBatchResponse> SendMessageBatchAsync(string queueUrl, List<SendMessageBatchRequestEntry> entries, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public TagQueueResponse TagQueue(TagQueueRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(string queueUrl, Dictionary<string, string> attributes, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<TagQueueResponse> TagQueueAsync(TagQueueRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(SetQueueAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public UntagQueueResponse UntagQueue(UntagQueueRequest request)
-    {
-        throw new NotImplementedException();
-    }
+    public Task<StartMessageMoveTaskResponse> StartMessageMoveTaskAsync(StartMessageMoveTaskRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<UntagQueueResponse> UntagQueueAsync(UntagQueueRequest request, CancellationToken cancellationToken = new CancellationToken())
-    {
-        throw new NotImplementedException();
-    }
+    public Task<TagQueueResponse> TagQueueAsync(TagQueueRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Endpoint DetermineServiceOperationEndpoint(AmazonWebServiceRequest request) => throw new NotImplementedException();
+    public Task<UntagQueueResponse> UntagQueueAsync(UntagQueueRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
     public ISQSPaginatorFactory Paginators { get; }
 

--- a/src/NServiceBus.Transport.SQS.Tests/PolicyScrubber.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/PolicyScrubber.cs
@@ -8,18 +8,15 @@ public static class PolicyScrubber
 {
     public static string ScrubPolicy(string policyAsString)
     {
-        var scrubbed = Regex.Replace(policyAsString, "\"Sid\" : \"(.*)\",", string.Empty);
+        var scrubbed = Regex.Replace(policyAsString, "\"Sid\": \"(.*)\",", string.Empty);
         return RemoveUnnecessaryWhiteSpace(scrubbed);
     }
 
-    static string RemoveUnnecessaryWhiteSpace(string policyAsString)
-    {
-        return string.Join(Environment.NewLine, policyAsString.Split(new[]
-            {
+    static string RemoveUnnecessaryWhiteSpace(string policyAsString) =>
+        string.Join(Environment.NewLine, policyAsString.Split([
                 Environment.NewLine
-            }, StringSplitOptions.RemoveEmptyEntries)
+            ], StringSplitOptions.RemoveEmptyEntries)
             .Where(l => !string.IsNullOrWhiteSpace(l))
             .Select(l => l.TrimEnd())
         );
-    }
 }

--- a/src/NServiceBus.Transport.SQS.Tests/Receiving/MessageExtractionTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/Receiving/MessageExtractionTests.cs
@@ -233,15 +233,10 @@ class MessageExtractionTests
         Assert.That(transportMessage.Headers, Is.EquivalentTo(expectedTransportMessage.Headers), "Headers are not set correctly");
     }
 
-    class NativeMessageBuilder
+    class NativeMessageBuilder(string nativeMessageId)
     {
-        Message message;
-        Dictionary<string, string> headers = [];
-
-        public NativeMessageBuilder(string nativeMessageId)
-        {
-            message = new Message { MessageId = nativeMessageId };
-        }
+        readonly Message message = new() { MessageId = nativeMessageId, MessageAttributes = [] };
+        readonly Dictionary<string, string> headers = [];
 
         public NativeMessageBuilder If(bool condition, Action<NativeMessageBuilder> action)
         {
@@ -272,22 +267,24 @@ class MessageExtractionTests
 
         public Message Build()
         {
-            if (headers.Any())
+            if (headers.Count == 0)
             {
-                var serialized = JsonSerializer.Serialize(headers);
-                message.MessageAttributes.Add(TransportHeaders.Headers, new MessageAttributeValue
-                {
-                    StringValue = serialized
-                });
-                ;
+                return message;
             }
+
+            var serialized = JsonSerializer.Serialize(headers);
+            message.MessageAttributes.Add(TransportHeaders.Headers, new MessageAttributeValue
+            {
+                StringValue = serialized
+            });
+            ;
             return message;
         }
     }
 
     class TransportMessageBuilder
     {
-        TransportMessage message = new TransportMessage
+        readonly TransportMessage message = new TransportMessage
         {
             Headers = []
         };

--- a/src/NServiceBus.Transport.SQS.Tests/Receiving/SubscriptionManagerTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/Receiving/SubscriptionManagerTests.cs
@@ -248,7 +248,7 @@ public class SubscriptionManagerTests
             return original(s);
         };
 
-        Assert.DoesNotThrowAsync(async () => await manager.SubscribeAll(new[] { new MessageMetadata(typeof(Event)) }, null));
+        Assert.DoesNotThrowAsync(async () => await manager.SubscribeAll([new MessageMetadata(typeof(Event))], null));
         Assert.That(manager.Delays, Has.Count.EqualTo(7));
         Assert.That(manager.Delays.Sum(), Is.EqualTo(35000));
     }

--- a/src/NServiceBus.Transport.SQS.TransportTests/Sending_poison_messages.cs
+++ b/src/NServiceBus.Transport.SQS.TransportTests/Sending_poison_messages.cs
@@ -1,5 +1,7 @@
 ﻿namespace TransportTests;
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,11 +49,14 @@ public class Sending_poison_messages : NServiceBusTransportTest
         {
             QueueUrl = queueUrl,
             MessageBody = UnwrappedAndNotRelevantPoisonMessageBody,
-            MessageAttributes =
+            MessageAttributes = new Dictionary<string, MessageAttributeValue>
             {
-                [TransportHeaders.Headers] = new MessageAttributeValue
                 {
-                    StringValue = "junk:this.will.fail.deserializing", DataType = "String"
+                    TransportHeaders.Headers, new MessageAttributeValue
+                    {
+                        StringValue = "junk:this.will.fail.deserializing",
+                        DataType = "String"
+                    }
                 }
             }
         };

--- a/src/NServiceBus.Transport.SQS/Administration/QueueCreator.cs
+++ b/src/NServiceBus.Transport.SQS/Administration/QueueCreator.cs
@@ -88,7 +88,7 @@ class QueueCreator(
         {
             // determine if the configured bucket exists; create it if it doesn't
             var listBucketsResponse = await s3Settings.S3Client.ListBucketsAsync(new ListBucketsRequest(), cancellationToken).ConfigureAwait(false);
-            var bucketExists = listBucketsResponse.Buckets.Any(x => string.Equals(x.BucketName, s3Settings.BucketName, StringComparison.InvariantCultureIgnoreCase));
+            var bucketExists = (listBucketsResponse.Buckets ?? []).Any(x => string.Equals(x.BucketName, s3Settings.BucketName, StringComparison.InvariantCultureIgnoreCase));
             if (!bucketExists)
             {
                 await s3Settings.S3Client.RetryConflictsAsync(async token =>

--- a/src/NServiceBus.Transport.SQS/Administration/QueueCreator.cs
+++ b/src/NServiceBus.Transport.SQS/Administration/QueueCreator.cs
@@ -99,7 +99,7 @@ class QueueCreator(
             }
 
             var lifecycleConfig = await s3Settings.S3Client.GetLifecycleConfigurationAsync(s3Settings.BucketName, cancellationToken).ConfigureAwait(false);
-            var setLifecycleConfig = lifecycleConfig.Configuration.Rules.All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
+            var setLifecycleConfig = (lifecycleConfig.Configuration.Rules ?? []).All(x => x.Id != "NServiceBus.SQS.DeleteMessageBodies");
 
             if (setLifecycleConfig)
             {

--- a/src/NServiceBus.Transport.SQS/Administration/QueueCreator.cs
+++ b/src/NServiceBus.Transport.SQS/Administration/QueueCreator.cs
@@ -40,10 +40,12 @@ class QueueCreator(
         // change the MaxTTLDays configuration property.
         var sqsAttributesRequest = new SetQueueAttributesRequest
         {
-            QueueUrl = createQueueResponse.QueueUrl
+            QueueUrl = createQueueResponse.QueueUrl,
+            Attributes = new Dictionary<string, string>
+            {
+                { QueueAttributeName.MessageRetentionPeriod, maxTimeToLive.TotalSeconds.ToString(CultureInfo.InvariantCulture) }
+            }
         };
-        sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod,
-            maxTimeToLive.TotalSeconds.ToString(CultureInfo.InvariantCulture));
 
         await sqsClient.SetQueueAttributesAsync(sqsAttributesRequest, cancellationToken).ConfigureAwait(false);
 
@@ -68,15 +70,17 @@ class QueueCreator(
 
             sqsAttributesRequest = new SetQueueAttributesRequest
             {
-                QueueUrl = createQueueResponse.QueueUrl
+                QueueUrl = createQueueResponse.QueueUrl,
+                Attributes = new Dictionary<string, string>
+                {
+                    { QueueAttributeName.MessageRetentionPeriod, TransportConstraints.DelayedDeliveryQueueMessageRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture) },
+                }
             };
 
             // Set the queue attributes in a separate call.
             // If you call CreateQueue with a queue name that already exists, and with a different
             // value for MessageRetentionPeriod, the service throws. This will happen if you
             // change the MaxTTLDays configuration property.
-            sqsAttributesRequest.Attributes.Add(QueueAttributeName.MessageRetentionPeriod, TransportConstraints.DelayedDeliveryQueueMessageRetentionPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture));
-
             await sqsClient.SetQueueAttributesAsync(sqsAttributesRequest, cancellationToken).ConfigureAwait(false);
         }
 
@@ -130,5 +134,5 @@ class QueueCreator(
         }
     }
 
-    static ILog Logger = LogManager.GetLogger(typeof(QueueCreator));
+    static readonly ILog Logger = LogManager.GetLogger(typeof(QueueCreator));
 }

--- a/src/NServiceBus.Transport.SQS/Extensions/PolicyExtensions.cs
+++ b/src/NServiceBus.Transport.SQS/Extensions/PolicyExtensions.cs
@@ -88,12 +88,7 @@ static class PolicyExtensions
 
     internal static Policy ExtractPolicy(this Dictionary<string, string> queueAttributes)
     {
-        string policyStr = null;
-        if (queueAttributes.ContainsKey("Policy"))
-        {
-            policyStr = queueAttributes["Policy"];
-        }
-
+        _ = queueAttributes.TryGetValue("Policy", out string policyStr);
         return string.IsNullOrEmpty(policyStr) ? new Policy() : Policy.FromJson(policyStr);
     }
 

--- a/src/NServiceBus.Transport.SQS/Extensions/PolicyExtensions.cs
+++ b/src/NServiceBus.Transport.SQS/Extensions/PolicyExtensions.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Amazon.Auth.AccessControlPolicy;
-using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
 #pragma warning disable 618
 static class PolicyExtensions
@@ -182,7 +181,7 @@ static class PolicyExtensions
     internal static Statement CreatePermissionStatementForQueueMatching(string queueArn, IEnumerable<string> topicArnMatchPatterns)
     {
         var statement = new Statement(Statement.StatementEffect.Allow);
-        statement.Actions.Add(SQSActionIdentifiers.SendMessage);
+        statement.Actions.Add(new ActionIdentifier("sqs:SendMessage"));
         statement.Resources.Add(new Resource(queueArn));
         statement.Principals.Add(new Principal("*"));
         var queuePermissionCondition = new Condition(ConditionFactory.ArnComparisonType.ArnLike.ToString(), "aws:SourceArn", topicArnMatchPatterns.OrderBy(t => t, OrdinalComparer).ToArray());

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.416.16" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.0" />
     <!-- Required for IAM Roles for Service Accounts even though no API is added -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.401.89" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400.140" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.140" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.3" />
     <PackageReference Include="NServiceBus" Version="9.2.7" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.0.2" />
     <!-- Required for IAM Roles for Service Accounts even though no API is added -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.0.2" />
     <PackageReference Include="BitFaster.Caching" Version="2.5.3" />
     <PackageReference Include="NServiceBus" Version="9.2.7" />
   </ItemGroup>

--- a/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using Extensions;
@@ -139,7 +140,7 @@ class DelayedMessagesPump(string receiveAddress, IAmazonSQS sqsClient, QueueCach
             return;
         }
 
-        var clockCorrection = sqsClient.Config.ClockOffset;
+        var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(sqsClient.Config.ServiceURL);
         var preparedMessages = PrepareMessages(receivedMessages, clockCorrection, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
@@ -139,7 +139,8 @@ class DelayedMessagesPump(string receiveAddress, IAmazonSQS sqsClient, QueueCach
         var receivedMessages = await sqsClient.ReceiveMessageAsync(request, cancellationToken).ConfigureAwait(false);
         if (receivedMessages.Messages is { Count: > 0 })
         {
-            var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(endpointUrl);
+            // In some unit test the pump is not started, with the consequence that the endpoint URL is never evaluated
+            var clockCorrection = endpointUrl == null ? TimeSpan.Zero : CorrectClockSkew.GetClockCorrectionForEndpoint(endpointUrl);
             var preparedMessages = PrepareMessages(receivedMessages, clockCorrection, cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
@@ -158,13 +158,13 @@ class DelayedMessagesPump(string receiveAddress, IAmazonSQS sqsClient, QueueCach
             preparedMessages ??= new List<SqsReceivedDelayedMessage>(receivedMessages.Messages.Count);
             long delaySeconds = 0;
 
-            if (receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.DelaySeconds, out var delayAttribute))
+            if (receivedMessage.MessageAttributes?.TryGetValue(TransportHeaders.DelaySeconds, out var delayAttribute) is true)
             {
                 long.TryParse(delayAttribute.StringValue, out delaySeconds);
             }
 
-            string originalMessageId = null;
-            if (receivedMessage.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute))
+            string originalMessageId = receivedMessage.MessageId;
+            if (receivedMessage.MessageAttributes?.TryGetValue(Headers.MessageId, out var messageIdAttribute) is true)
             {
                 originalMessageId = messageIdAttribute.StringValue;
             }

--- a/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
@@ -137,7 +137,9 @@ class DelayedMessagesPump(string receiveAddress, IAmazonSQS sqsClient, QueueCach
         var receivedMessages = await sqsClient.ReceiveMessageAsync(request, cancellationToken).ConfigureAwait(false);
         if (receivedMessages.Messages is { Count: > 0 })
         {
-            var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(sqsClient.Config.ServiceURL);
+            // TODO revise clock skew correction logic
+            var endpoint = sqsClient.DetermineServiceOperationEndpoint(request).URL;
+            var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(endpoint);
             var preparedMessages = PrepareMessages(receivedMessages, clockCorrection, cancellationToken);
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
@@ -8,6 +8,7 @@ namespace NServiceBus.Transport.SQS
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
+    using Amazon.Runtime;
     using Amazon.SQS;
     using Amazon.SQS.Model;
     using BitFaster.Caching.Lru;
@@ -319,7 +320,9 @@ namespace NServiceBus.Transport.SQS
                     return;
                 }
 
-                if (IsMessageExpired(receivedMessage, transportMessage.Headers, messageId, sqsClient.Config.ClockOffset))
+
+                var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(sqsClient.Config.ServiceURL);
+                if (IsMessageExpired(receivedMessage, transportMessage.Headers, messageId, clockCorrection))
                 {
                     await DeleteMessage(receivedMessage, transportMessage.S3BodyKey).ConfigureAwait(false);
                 }

--- a/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
@@ -351,21 +351,15 @@ namespace NServiceBus.Transport.SQS
         }
 
 
-        public static string ExtractMessageId(Message receivedMessage)
-        {
-            if (receivedMessage.MessageAttributes != null &&
-                receivedMessage.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute))
-            {
-                return messageIdAttribute.StringValue;
-            }
-
-            return receivedMessage.MessageId;
-        }
+        public static string ExtractMessageId(Message receivedMessage) =>
+            receivedMessage.MessageAttributes?.TryGetValue(Headers.MessageId, out var messageIdAttribute) is true
+                ? messageIdAttribute.StringValue
+                : receivedMessage.MessageId;
 
         public static TransportMessage ExtractTransportMessage(Message receivedMessage, string messageIdOverride)
         {
             TransportMessage transportMessage;
-            if (receivedMessage.MessageAttributes != null && receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.Headers, out var headersAttribute))
+            if (receivedMessage.MessageAttributes?.TryGetValue(TransportHeaders.Headers, out var headersAttribute) is true)
             {
                 var headers = JsonSerializer.Deserialize<Dictionary<string, string>>(headersAttribute.StringValue) ?? [];
                 transportMessage = new TransportMessage
@@ -383,7 +377,7 @@ namespace NServiceBus.Transport.SQS
             else
             {
                 // When the MessageTypeFullName attribute is available, we're assuming native integration
-                if (receivedMessage.MessageAttributes != null && receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.MessageTypeFullName, out var enclosedMessageType))
+                if (receivedMessage.MessageAttributes?.TryGetValue(TransportHeaders.MessageTypeFullName, out var enclosedMessageType) is true)
                 {
                     transportMessage = new TransportMessage
                     {
@@ -642,7 +636,7 @@ namespace NServiceBus.Transport.SQS
                     .ConfigureAwait(false);
                 // Ok to use LINQ here since this is not really a hot path
                 var messageAttributeValues = message.MessageAttributes
-                    .ToDictionary(pair => pair.Key, messageAttribute => messageAttribute.Value);
+                    ?.ToDictionary(pair => pair.Key, messageAttribute => messageAttribute.Value);
 
                 await sqsClient.SendMessageAsync(new SendMessageRequest
                 {

--- a/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
@@ -325,7 +325,8 @@ namespace NServiceBus.Transport.SQS
                     return;
                 }
 
-                var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(endpointUrl);
+                // In some unit test the pump is not started, with the consequence that the endpoint URL is never evaluated
+                var clockCorrection = endpointUrl == null ? TimeSpan.Zero : CorrectClockSkew.GetClockCorrectionForEndpoint(endpointUrl);
                 if (IsMessageExpired(receivedMessage, transportMessage.Headers, messageId, clockCorrection))
                 {
                     await DeleteMessage(receivedMessage, transportMessage.S3BodyKey).ConfigureAwait(false);

--- a/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
@@ -351,15 +351,21 @@ namespace NServiceBus.Transport.SQS
         }
 
 
-        public static string ExtractMessageId(Message receivedMessage) =>
-            receivedMessage.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute)
-                ? messageIdAttribute.StringValue
-                : receivedMessage.MessageId;
+        public static string ExtractMessageId(Message receivedMessage)
+        {
+            if (receivedMessage.MessageAttributes != null &&
+                receivedMessage.MessageAttributes.TryGetValue(Headers.MessageId, out var messageIdAttribute))
+            {
+                return messageIdAttribute.StringValue;
+            }
+
+            return receivedMessage.MessageId;
+        }
 
         public static TransportMessage ExtractTransportMessage(Message receivedMessage, string messageIdOverride)
         {
             TransportMessage transportMessage;
-            if (receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.Headers, out var headersAttribute))
+            if (receivedMessage.MessageAttributes != null && receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.Headers, out var headersAttribute))
             {
                 var headers = JsonSerializer.Deserialize<Dictionary<string, string>>(headersAttribute.StringValue) ?? [];
                 transportMessage = new TransportMessage
@@ -377,7 +383,7 @@ namespace NServiceBus.Transport.SQS
             else
             {
                 // When the MessageTypeFullName attribute is available, we're assuming native integration
-                if (receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.MessageTypeFullName, out var enclosedMessageType))
+                if (receivedMessage.MessageAttributes != null && receivedMessage.MessageAttributes.TryGetValue(TransportHeaders.MessageTypeFullName, out var enclosedMessageType))
                 {
                     transportMessage = new TransportMessage
                     {

--- a/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/InputQueuePump.cs
@@ -323,8 +323,9 @@ namespace NServiceBus.Transport.SQS
                     return;
                 }
 
-
-                var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(sqsClient.Config.ServiceURL);
+                // TODO revise clock skew correction logic
+                var endpoint = sqsClient.DetermineServiceOperationEndpoint(receiveMessagesRequest).URL;
+                var clockCorrection = CorrectClockSkew.GetClockCorrectionForEndpoint(endpoint);
                 if (IsMessageExpired(receivedMessage, transportMessage.Headers, messageId, clockCorrection))
                 {
                     await DeleteMessage(receivedMessage, transportMessage.S3BodyKey).ConfigureAwait(false);

--- a/src/NServiceBus.Transport.SQS/Receiving/PolicyStatement.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/PolicyStatement.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Linq;
 using Amazon.Auth.AccessControlPolicy;
-using Amazon.Auth.AccessControlPolicy.ActionIdentifiers;
 
 #pragma warning disable 618
 class PolicyStatement
@@ -28,7 +27,7 @@ class PolicyStatement
     internal static Statement CreatePermissionStatement(string queueArn, string topicArn)
     {
         var statement = new Statement(Statement.StatementEffect.Allow);
-        statement.Actions.Add(SQSActionIdentifiers.SendMessage);
+        statement.Actions.Add(new ActionIdentifier("sqs:SendMessage"));
         statement.Resources.Add(new Resource(queueArn));
         statement.Conditions.Add(ConditionFactory.NewSourceArnCondition(topicArn));
         statement.Principals.Add(new Principal("*"));

--- a/src/NServiceBus.Transport.SQS/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/Sending/MessageDispatcher.cs
@@ -426,7 +426,7 @@ partial class MessageDispatcher(
         return delaySeconds;
     }
 
-    Dictionary<string, MessageAttributeValue>? GetNativeMessageAttributes(UnicastTransportOperation transportOperation, TransportTransaction transportTransaction)
+    static Dictionary<string, MessageAttributeValue>? GetNativeMessageAttributes(UnicastTransportOperation transportOperation, TransportTransaction transportTransaction)
     {
         // In case we're handling a message of which the incoming message id equals the outgoing message id, we're essentially handling an error or audit scenario, in which case we want copy over the message attributes
         // from the native message, so we don't lose part of the message

--- a/src/NServiceBus.Transport.SQS/Sending/MessageDispatcher.cs
+++ b/src/NServiceBus.Transport.SQS/Sending/MessageDispatcher.cs
@@ -170,17 +170,16 @@ partial class MessageDispatcher(
                 Logger.Debug($"Sent batch '{batchNumber}/{totalBatches}' with message ids '{string.Join(", ", batch.PreparedMessagesBydId.Values.Select(v => v.MessageId))}' to destination {message.Destination}");
             }
 
-            List<Task>? redispatchTasks = null;
-            foreach (var errorEntry in result.Failed)
+            if (result.Failed is { Count: > 0 })
             {
-                redispatchTasks ??= new List<Task>(result.Failed.Count);
-                var messageToRetry = batch.PreparedMessagesBydId[errorEntry.Id];
-                Logger.Info($"Retrying message with MessageId {messageToRetry.MessageId} that failed in batch '{batchNumber}/{totalBatches}' due to '{errorEntry.Message}'.");
-                redispatchTasks.Add(SendMessageForBatch(messageToRetry, batchNumber, totalBatches, cancellationToken));
-            }
+                var redispatchTasks = new List<Task>(result.Failed.Count);
+                foreach (var errorEntry in result.Failed)
+                {
 
-            if (redispatchTasks != null)
-            {
+                    var messageToRetry = batch.PreparedMessagesBydId[errorEntry.Id];
+                    Logger.Info($"Retrying message with MessageId {messageToRetry.MessageId} that failed in batch '{batchNumber}/{totalBatches}' due to '{errorEntry.Message}'.");
+                    redispatchTasks.Add(SendMessageForBatch(messageToRetry, batchNumber, totalBatches, cancellationToken));
+                }
                 await Task.WhenAll(redispatchTasks).ConfigureAwait(false);
             }
         }
@@ -231,17 +230,15 @@ partial class MessageDispatcher(
                 Logger.Debug($"Published batch '{batchNumber}/{totalBatches}' with message ids '{string.Join(", ", batch.PreparedMessagesBydId.Values.Select(v => v.MessageId))}' to destination {message.Destination}");
             }
 
-            List<Task>? redispatchTasks = null;
-            foreach (var errorEntry in result.Failed)
+            if (result.Failed is { Count: > 0 })
             {
-                redispatchTasks ??= new List<Task>(result.Failed.Count);
-                var messageToRetry = batch.PreparedMessagesBydId[errorEntry.Id];
-                Logger.Info($"Republishing message with MessageId {messageToRetry.MessageId} that failed in batch '{batchNumber}/{totalBatches}' due to '{errorEntry.Message}'.");
-                redispatchTasks.Add(PublishForBatch(messageToRetry, batchNumber, totalBatches, cancellationToken));
-            }
-
-            if (redispatchTasks != null)
-            {
+                var redispatchTasks = new List<Task>(result.Failed.Count);
+                foreach (var errorEntry in result.Failed)
+                {
+                    var messageToRetry = batch.PreparedMessagesBydId[errorEntry.Id];
+                    Logger.Info($"Republishing message with MessageId {messageToRetry.MessageId} that failed in batch '{batchNumber}/{totalBatches}' due to '{errorEntry.Message}'.");
+                    redispatchTasks.Add(PublishForBatch(messageToRetry, batchNumber, totalBatches, cancellationToken));
+                }
                 await Task.WhenAll(redispatchTasks).ConfigureAwait(false);
             }
         }

--- a/src/NServiceBus.Transport.SQS/Sending/SnsPreparedMessage.cs
+++ b/src/NServiceBus.Transport.SQS/Sending/SnsPreparedMessage.cs
@@ -9,7 +9,7 @@ class SnsPreparedMessage
     public string MessageId
     {
         get => MessageAttributes.ContainsKey(Headers.MessageId) ? MessageAttributes[Headers.MessageId].StringValue : null;
-        set =>
+        init =>
             // because message attributes are part of the content size restriction we want to prevent message size from changing thus we add it 
             // for native delayed deliver as well even though the information is slightly redundant (MessageId is assigned to MessageDeduplicationId for example)
             MessageAttributes[Headers.MessageId] = new MessageAttributeValue
@@ -35,10 +35,9 @@ class SnsPreparedMessage
     long CalculateAttributesSize()
     {
         var size = 0L;
-        foreach (var messageAttributeValue in MessageAttributes)
+        foreach ((string key, MessageAttributeValue attributeValue) in MessageAttributes)
         {
-            size += messageAttributeValue.Key.Length;
-            var attributeValue = messageAttributeValue.Value;
+            size += key.Length;
             size += attributeValue.DataType?.Length ?? 0;
             size += attributeValue.StringValue?.Length ?? 0;
 

--- a/src/NServiceBus.Transport.SQS/Sending/SqsPreparedMessage.cs
+++ b/src/NServiceBus.Transport.SQS/Sending/SqsPreparedMessage.cs
@@ -9,7 +9,7 @@ class SqsPreparedMessage
     public string MessageId
     {
         get => MessageAttributes.ContainsKey(Headers.MessageId) ? MessageAttributes[Headers.MessageId].StringValue : null;
-        set =>
+        init =>
             // because message attributes are part of the content size restriction we want to prevent message size from changing thus we add it
             // for native delayed deliver as well even though the information is slightly redundant (MessageId is assigned to MessageDeduplicationId for example)
             MessageAttributes[Headers.MessageId] = new MessageAttributeValue
@@ -21,7 +21,6 @@ class SqsPreparedMessage
     public string Body { get; set; }
     public string Destination { get; set; }
     public long Size { get; private set; }
-
     public string OriginalDestination { get; set; }
     public string QueueUrl { get; set; }
     public int DelaySeconds { get; set; }


### PR DESCRIPTION
This pull request is currently blocked due to a policy deserialization issue in the AWS SDK that should be fixed soon

What is left to do:

- [x] Update to the SDK with the [bug fix
](https://github.com/aws/aws-sdk-net/issues/3791)
- [x] Figure out the clock skew code and whether it requires caching. It would also be possible to switch to something like

```csharp
var serviceOperationEndpoint = sqsClient.Config.DetermineServiceOperationEndpoint(new ServiceOperationEndpointParameters(new GetCallerIdentityRequest()));
                var clockSkew = CorrectClockSkew.GetClockCorrectionForEndpoint(serviceOperationEndpoint.URL);
```

- [x] Do further checks on the code path to figure out whether all the collection types have appropriate null checks.