### PR TITLE
Update NServiceBus packages to 10.2.0-alpha.8

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.1.4" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="10.2.0-alpha.8" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/NServiceBus.Transport.SQS.TransportTests.DoNotWrapOutgoingMessages/NServiceBus.Transport.SQS.TransportTests.DoNotWrapOutgoingMessages.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests.DoNotWrapOutgoingMessages/NServiceBus.Transport.SQS.TransportTests.DoNotWrapOutgoingMessages.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="10.1.4" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="10.2.0-alpha.8" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
+++ b/src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="10.1.4" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.TransportTests.Sources" Version="10.2.0-alpha.8" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
+++ b/src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -14,11 +14,11 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.30" />
     <PackageReference Include="AWSSDK.SQS" Version="4.0.2.28" />
     <PackageReference Include="BitFaster.Caching" Version="2.6.0" />
-    <PackageReference Include="NServiceBus" Version="10.1.4" />
+    <PackageReference Include="NServiceBus" Version="10.2.0-alpha.8" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Obsoletes" Version="1.1.0"  PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Particular.Obsoletes" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates the NServiceBus package family to `10.2.0-alpha.8` in project files.

Updated package IDs:
- `NServiceBus`
- `NServiceBus.AcceptanceTesting`
- `NServiceBus.AcceptanceTests.Sources`
- `NServiceBus.PersistenceTests.Sources`
- `NServiceBus.TransportTests.Sources`

Changed `.csproj` files:
- `src/NServiceBus.Transport.SQS.AcceptanceTests/NServiceBus.Transport.SQS.AcceptanceTests.csproj` (`NServiceBus.AcceptanceTests.Sources`)
- `src/NServiceBus.Transport.SQS.TransportTests.DoNotWrapOutgoingMessages/NServiceBus.Transport.SQS.TransportTests.DoNotWrapOutgoingMessages.csproj` (`NServiceBus.TransportTests.Sources`)
- `src/NServiceBus.Transport.SQS.TransportTests/NServiceBus.Transport.SQS.TransportTests.csproj` (`NServiceBus.TransportTests.Sources`)
- `src/NServiceBus.Transport.SQS/NServiceBus.Transport.SQS.csproj` (`NServiceBus`)

Generated by a LINQPad bulk-update script using Octokit.