### PR TITLE
Mark message-driven pub/sub compatibility mode as obsolete

### DIFF
--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -68,7 +68,9 @@ public class When_publishing_one_event_type_to_native_and_non_native_subscribers
             {
                 b.CustomConfig(config =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                     migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
                 });

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -69,6 +69,7 @@ public class When_publishing_one_event_type_to_native_and_non_native_subscribers
                 b.CustomConfig(config =>
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -76,7 +76,9 @@ public class When_publishing_one_event_type_to_native_and_non_native_subscribers
             {
                 b.CustomConfig(config =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                     migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
                     config.ConfigureSqsTransport().MessageVisibilityTimeout = testCase.MessageVisibilityTimeout;

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_one_event_type_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -77,6 +77,7 @@ public class When_publishing_one_event_type_to_native_and_non_native_subscribers
                 b.CustomConfig(config =>
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -78,7 +78,9 @@ public class When_publishing_two_event_types_to_native_and_non_native_subscriber
             {
                 b.CustomConfig(config =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                     migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
                 });

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop.cs
@@ -79,6 +79,7 @@ public class When_publishing_two_event_types_to_native_and_non_native_subscriber
                 b.CustomConfig(config =>
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -97,7 +97,9 @@ public class When_publishing_two_event_types_to_native_and_non_native_subscriber
             {
                 b.CustomConfig(config =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);
                     migrationMode.TopicCacheTTL(testCase.NotFoundTopicsCacheTTL);
                     config.ConfigureSqsTransport().MessageVisibilityTimeout = testCase.MessageVisibilityTimeout;

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/HybridModeRateLimit/When_publishing_two_event_types_to_native_and_non_native_subscribers_in_a_loop_in_the_context_of_incoming_message.cs
@@ -98,6 +98,7 @@ public class When_publishing_two_event_types_to_native_and_non_native_subscriber
                 b.CustomConfig(config =>
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var migrationMode = config.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                     migrationMode.SubscriptionsCacheTTL(testCase.SubscriptionsCacheTTL);

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
@@ -55,6 +55,7 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                 });
@@ -84,6 +85,7 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                 });
@@ -94,6 +96,7 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_publisher_first.cs
@@ -54,7 +54,9 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 });
                 b.When(session => session.Publish(new MyEvent()));
             })
@@ -81,7 +83,9 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 });
                 b.When(c => c.SubscribedMessageDriven && c.SubscribedNative, session => session.Publish(new MyEvent()));
             })
@@ -89,7 +93,9 @@ public class When_migrating_publisher_first : NServiceBusAcceptanceTest
             {
                 b.CustomConfig(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // not needed but left here to enforce duplicates
                     compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
@@ -62,7 +62,9 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
             {
                 b.CustomConfig(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 });
@@ -84,7 +86,9 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
+#pragma warning disable CS0618 // Type or member is obsolete
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 });
                 b.When(c => c.SubscribedMessageDriven && c.SubscribedNative, session => session.Publish(new MyEvent()));
             })
@@ -92,7 +96,9 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
             {
                 b.CustomConfig(c =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // not needed but left here to enforce duplicates
                     compatModeSettings.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_migrating_subscriber_first.cs
@@ -63,6 +63,7 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
 
@@ -87,6 +88,7 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
                 {
                     c.UsePersistence<TestingInMemoryPersistence, StorageType.Subscriptions>().UseStorage(subscriptionStorage);
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                 });
@@ -97,6 +99,7 @@ public class When_migrating_subscriber_first : NServiceBusAcceptanceTest
                 b.CustomConfig(c =>
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
+                    // When message-driven compatibility mode is obsoleted with an error this test can be removed
                     var compatModeSettings = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
@@ -36,7 +36,9 @@ public class When_publisher_runs_in_compat_mode : NServiceBusAcceptanceTest
         public MigratedPublisher() =>
             EndpointSetup<DefaultPublisher>(c =>
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 c.OnEndpointSubscribed<Context>((s, context) =>
                 {

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_publisher_runs_in_compat_mode.cs
@@ -37,6 +37,7 @@ public class When_publisher_runs_in_compat_mode : NServiceBusAcceptanceTest
             EndpointSetup<DefaultPublisher>(c =>
             {
 #pragma warning disable CS0618 // Type or member is obsolete
+                // When message-driven compatibility mode is obsoleted with an error this test can be removed
                 c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
@@ -52,6 +52,7 @@ public class When_subscriber_runs_in_compat_mode : NServiceBusAcceptanceTest
             EndpointSetup<DefaultServer>(c =>
             {
 #pragma warning disable CS0618 // Type or member is obsolete
+                // When message-driven compatibility mode is obsoleted with an error this test can be removed
                 var compatMode = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
 #pragma warning restore CS0618 // Type or member is obsolete
                 compatMode.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);

--- a/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
+++ b/src/NServiceBus.Transport.SQS.AcceptanceTests/NativePubSub/When_subscriber_runs_in_compat_mode.cs
@@ -51,7 +51,9 @@ public class When_subscriber_runs_in_compat_mode : NServiceBusAcceptanceTest
         public MigratedSubscriber() =>
             EndpointSetup<DefaultServer>(c =>
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var compatMode = c.ConfigureRouting().EnableMessageDrivenPubSubCompatibilityMode();
+#pragma warning restore CS0618 // Type or member is obsolete
                 compatMode.RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 c.DisableFeature<AutoSubscribe>();
             });

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
@@ -6,11 +6,13 @@ namespace NServiceBus
 {
     public static class MessageDrivenPubSubCompatibilityModeConfiguration
     {
-        [System.Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treate" +
-            "d as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+        [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
+            "ll be treated as an error from version 10.0.0. Will be removed in version 11.0.0" +
+            ".", false)]
         public static NServiceBus.Transport.SQS.Configure.SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.RoutingSettings routingSettings) { }
-        [System.Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treate" +
-            "d as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+        [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
+            "ll be treated as an error from version 10.0.0. Will be removed in version 11.0.0" +
+            ".", false)]
         public static NServiceBus.Transport.SQS.Configure.SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions) { }
     }
     public class PolicySettings
@@ -104,8 +106,9 @@ namespace NServiceBus
 }
 namespace NServiceBus.Transport.SQS.Configure
 {
-    [System.Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treate" +
-        "d as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+    [System.Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Wi" +
+        "ll be treated as an error from version 10.0.0. Will be removed in version 11.0.0" +
+        ".", false)]
     public class SqsSubscriptionMigrationModeSettings : NServiceBus.SubscriptionMigrationModeSettings
     {
         public NServiceBus.SubscriptionMigrationModeSettings SubscriptionsCacheTTL(System.TimeSpan ttl) { }

--- a/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
+++ b/src/NServiceBus.Transport.SQS.Tests/ApprovalFiles/APIApprovals.ApproveSqsTransport.approved.txt
@@ -6,7 +6,11 @@ namespace NServiceBus
 {
     public static class MessageDrivenPubSubCompatibilityModeConfiguration
     {
+        [System.Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treate" +
+            "d as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
         public static NServiceBus.Transport.SQS.Configure.SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.RoutingSettings routingSettings) { }
+        [System.Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treate" +
+            "d as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
         public static NServiceBus.Transport.SQS.Configure.SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this NServiceBus.TransportExtensions<NServiceBus.SqsTransport> transportExtensions) { }
     }
     public class PolicySettings
@@ -100,6 +104,8 @@ namespace NServiceBus
 }
 namespace NServiceBus.Transport.SQS.Configure
 {
+    [System.Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treate" +
+        "d as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
     public class SqsSubscriptionMigrationModeSettings : NServiceBus.SubscriptionMigrationModeSettings
     {
         public NServiceBus.SubscriptionMigrationModeSettings SubscriptionsCacheTTL(System.TimeSpan ttl) { }

--- a/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
@@ -7,8 +7,8 @@ using Particular.Obsoletes;
 /// <summary>
 /// Publish-subscribe migration mode configuration.
 /// </summary>
-[Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
-[ObsoleteMetadata(Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead",
+[Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+[ObsoleteMetadata(Message = "Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub",
     TreatAsErrorFromVersion = "10.0.0",
     RemoveInVersion = "11.0.0")]
 public partial class SqsSubscriptionMigrationModeSettings : SubscriptionMigrationModeSettings

--- a/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsSubscriptionMigrationModeSettings.cs
@@ -7,9 +7,10 @@ using Particular.Obsoletes;
 /// <summary>
 /// Publish-subscribe migration mode configuration.
 /// </summary>
-[PreObsolete("https://github.com/Particular/NServiceBus/issues/6471",
-    Note = "Hybrid pub/sub support cannot be obsolete until there is a viable migration path to native pub/sub",
-    Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead")]
+[Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+[ObsoleteMetadata(Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead",
+    TreatAsErrorFromVersion = "10.0.0",
+    RemoveInVersion = "11.0.0")]
 public partial class SqsSubscriptionMigrationModeSettings : SubscriptionMigrationModeSettings
 {
     SettingsHolder settings;

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
@@ -291,9 +291,10 @@ public static class MessageDrivenPubSubCompatibilityModeConfiguration
     /// Enables compatibility with endpoints running on message-driven pub-sub
     /// </summary>
     /// <param name="transportExtensions">The transport to enable pub-sub compatibility on</param>
-    [PreObsolete("https://github.com/Particular/NServiceBus/issues/6471",
-        Note = "Hybrid pub/sub support cannot be obsolete until there is a viable migration path to native pub/sub",
-        Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead")]
+    [Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+    [ObsoleteMetadata(Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead",
+        TreatAsErrorFromVersion = "10.0.0",
+        RemoveInVersion = "11.0.0")]
     public static SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<SqsTransport> transportExtensions)
     {
         var routingSettings = transportExtensions.Routing();
@@ -306,11 +307,12 @@ public static class MessageDrivenPubSubCompatibilityModeConfiguration
     ///     Enables compatibility with endpoints running on message-driven pub-sub
     /// </summary>
     /// <param name="routingSettings">The transport to enable pub-sub compatibility on</param>
-    [PreObsolete("https://github.com/Particular/NServiceBus/issues/6471",
-        Note = "Hybrid pub/sub support cannot be obsolete until there is a viable migration path to native pub/sub",
-        Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead")]
+    [Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+    [ObsoleteMetadata(Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead",
+        TreatAsErrorFromVersion = "10.0.0",
+        RemoveInVersion = "11.0.0")]
     public static SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(
-        this RoutingSettings routingSettings)
+            this RoutingSettings routingSettings)
     {
         var settings = routingSettings.GetSettings();
         settings.Set("NServiceBus.Subscriptions.EnableMigrationMode", true);

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportSettings.cs
@@ -291,8 +291,8 @@ public static class MessageDrivenPubSubCompatibilityModeConfiguration
     /// Enables compatibility with endpoints running on message-driven pub-sub
     /// </summary>
     /// <param name="transportExtensions">The transport to enable pub-sub compatibility on</param>
-    [Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
-    [ObsoleteMetadata(Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead",
+    [Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+    [ObsoleteMetadata(Message = "Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub",
         TreatAsErrorFromVersion = "10.0.0",
         RemoveInVersion = "11.0.0")]
     public static SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<SqsTransport> transportExtensions)
@@ -307,8 +307,8 @@ public static class MessageDrivenPubSubCompatibilityModeConfiguration
     ///     Enables compatibility with endpoints running on message-driven pub-sub
     /// </summary>
     /// <param name="routingSettings">The transport to enable pub-sub compatibility on</param>
-    [Obsolete("Hybrid pub/sub is no longer supported, use native pub/sub instead. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
-    [ObsoleteMetadata(Message = "Hybrid pub/sub is no longer supported, use native pub/sub instead",
+    [Obsolete("Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub. Will be treated as an error from version 10.0.0. Will be removed in version 11.0.0.", false)]
+    [ObsoleteMetadata(Message = "Hybrid pub/sub is deprecated and endpoints needs to migrate to native pub/sub",
         TreatAsErrorFromVersion = "10.0.0",
         RemoveInVersion = "11.0.0")]
     public static SqsSubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(


### PR DESCRIPTION
All uses of `EnableMessageDrivenPubSubCompatibilityMode` need to be marked as obsolete with a warning starting in the next minor version.

This also adds the `#pragma warning disable/restore` directives for tests only.