### PR TITLE
Decouple unrestricted delayed delivery from core delayed delivery

### DIFF
--- a/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/MockSqsClient.cs
@@ -204,7 +204,13 @@ class MockSqsClient : IAmazonSQS
 
     public Task<CreateQueueResponse> CreateQueueAsync(string queueName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<CreateQueueResponse> CreateQueueAsync(CreateQueueRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public ConcurrentQueue<CreateQueueRequest> CreateQueueRequestsSent { get; } = [];
+
+    public Task<CreateQueueResponse> CreateQueueAsync(CreateQueueRequest request, CancellationToken cancellationToken = default)
+    {
+        CreateQueueRequestsSent.Enqueue(request);
+        return Task.FromResult(new CreateQueueResponse { QueueUrl = request.QueueName });
+    }
 
     public Task<DeleteMessageBatchResponse> DeleteMessageBatchAsync(string queueUrl, List<DeleteMessageBatchRequestEntry> entries, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
@@ -242,7 +248,7 @@ class MockSqsClient : IAmazonSQS
 
     public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(string queueUrl, Dictionary<string, string> attributes, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-    public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(SetQueueAttributesRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<SetQueueAttributesResponse> SetQueueAttributesAsync(SetQueueAttributesRequest request, CancellationToken cancellationToken = default) => Task.FromResult(new SetQueueAttributesResponse());
 
     public Task<StartMessageMoveTaskResponse> StartMessageMoveTaskAsync(StartMessageMoveTaskRequest request, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 

--- a/src/NServiceBus.Transport.SQS.Tests/Receiving/DelayedMessagesPumpTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/Receiving/DelayedMessagesPumpTests.cs
@@ -44,11 +44,11 @@ public class DelayedMessagesPumpTests
         };
 
         var exception = Assert.ThrowsAsync<Exception>(async () => { await pump.Initialize(); });
-        Assert.That(exception.Message, Is.EqualTo("Delayed delivery queue 'queue-delay.fifo' has a Delivery Delay of '00:00:01'. It should be less than '00:15:00'."));
+        Assert.That(exception.Message, Is.EqualTo("Delayed delivery queue 'queue-delay.fifo' has a Delivery Delay of '00:00:01'. It should be at least '00:15:00'."));
     }
 
     [Test]
-    public void Initialize_retention_smaller_than_required_throws()
+    public void Initialize_retention_period_smaller_than_required_throws()
     {
         pump = new DelayedMessagesPump("queue", mockSqsClient, new QueueCache(mockSqsClient, q => QueueCache.GetSqsQueueName(q, "Prefix")), 15 * 60);
 
@@ -62,7 +62,7 @@ public class DelayedMessagesPumpTests
         };
 
         var exception = Assert.ThrowsAsync<Exception>(async () => { await pump.Initialize(); });
-        Assert.That(exception.Message, Is.EqualTo("Delayed delivery queue 'queue-delay.fifo' has a Message Retention Period of '00:00:10'. It should be less than '4.00:00:00'."));
+        Assert.That(exception.Message, Is.EqualTo("Delayed delivery queue 'queue-delay.fifo' has a Message Retention Period of '00:00:10'. It should be at least '4.00:00:00'."));
     }
 
     [Test]

--- a/src/NServiceBus.Transport.SQS.Tests/SqsTransportTests.cs
+++ b/src/NServiceBus.Transport.SQS.Tests/SqsTransportTests.cs
@@ -1,0 +1,39 @@
+namespace NServiceBus.Transport.SQS.Tests;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+[TestFixture]
+public class SqsTransportTests
+{
+    [Theory]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Should_always_support_native_delayed_delivery(bool disableUnrestrictedDelayedDelivery)
+    {
+        var transport = new SqsTransport(new MockSqsClient(), new MockSnsClient(), disableUnrestrictedDelayedDelivery: disableUnrestrictedDelayedDelivery);
+
+        Assert.That(transport.SupportsDelayedDelivery, Is.True);
+    }
+
+    [Theory]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_create_delayed_delivery_queue_only_when_unrestricted_delayed_delivery_enabled(bool disableUnrestrictedDelayedDelivery)
+    {
+        var sqsClient = new MockSqsClient();
+        var transport = new SqsTransport(sqsClient, new MockSnsClient(), disableUnrestrictedDelayedDelivery: disableUnrestrictedDelayedDelivery);
+
+        var hostSettings = new HostSettings("Test", "Test", new StartupDiagnosticEntries(), (_, _, _) => { }, setupInfrastructure: true);
+        var receivers = new[] { new ReceiveSettings("receiver", new QueueAddress("myqueue"), false, false, "error") };
+
+        await transport.Initialize(hostSettings, receivers, Array.Empty<string>());
+
+        var delayedDeliveryQueueCreated = sqsClient.CreateQueueRequestsSent
+            .Any(request => request.QueueName.EndsWith(TransportConstraints.DelayedDeliveryQueueSuffix, StringComparison.Ordinal));
+
+        Assert.That(delayedDeliveryQueueCreated, Is.EqualTo(!disableUnrestrictedDelayedDelivery));
+    }
+}

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransport.cs
@@ -274,7 +274,7 @@ public partial class SqsTransport : TransportDefinition
     /// </summary>
     /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed the <see cref="QueueDelayTime" /> value, which by default is 15 minutes.</paramref>.
     public SqsTransport(IAmazonSQS sqsClient, IAmazonSimpleNotificationService snsClient, bool disableUnrestrictedDelayedDelivery = false)
-        : this(sqsClient, snsClient, externallyManaged: true, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
+        : this(sqsClient, snsClient, externallyManaged: true, disableUnrestrictedDelayedDelivery: disableUnrestrictedDelayedDelivery)
     {
     }
 
@@ -285,7 +285,7 @@ public partial class SqsTransport : TransportDefinition
     /// </summary>
     /// <paramref name="disableUnrestrictedDelayedDelivery">If set to <c>true</c>, the unrestricted delayed delivery will be disabled. This causes the transport to fail with a <see cref="NServiceBus.Unicast.Queuing.QueueNotFoundException"/> when trying to send delayed messages that exceed the <see cref="QueueDelayTime" /> value, which by default is 15 minutes.</paramref>.
     public SqsTransport(bool disableUnrestrictedDelayedDelivery = false)
-        : this(DefaultClientFactories.SqsFactory(), DefaultClientFactories.SnsFactory(), externallyManaged: false, enableDelayedDelivery: !disableUnrestrictedDelayedDelivery)
+        : this(DefaultClientFactories.SqsFactory(), DefaultClientFactories.SnsFactory(), externallyManaged: false, disableUnrestrictedDelayedDelivery: disableUnrestrictedDelayedDelivery)
     {
     }
 
@@ -295,17 +295,18 @@ public partial class SqsTransport : TransportDefinition
         IAmazonSimpleNotificationService snsClient,
         bool externallyManaged,
         bool supportsPublishSubscribe = true,
-        bool enableDelayedDelivery = true
+        bool disableUnrestrictedDelayedDelivery = false
     )
         : base(
             TransportTransactionMode.ReceiveOnly,
-            enableDelayedDelivery,
+            supportsDelayedDelivery: true,
             supportsPublishSubscribe,
             supportsTTBR: true
         )
     {
         SetupSqsClient(sqsClient, externallyManaged);
         SetupSnsClient(snsClient, externallyManaged);
+        this.disableUnrestrictedDelayedDelivery = disableUnrestrictedDelayedDelivery;
     }
 
     /// <summary>
@@ -326,7 +327,6 @@ public partial class SqsTransport : TransportDefinition
             TopicNameGenerator,
             TopicNamePrefix
         );
-
         var infra = new SqsTransportInfrastructure(
             hostSettings,
             receivers,
@@ -343,7 +343,7 @@ public partial class SqsTransport : TransportDefinition
             DoNotWrapOutgoingMessages,
             !sqsClient.ExternallyManaged,
             !snsClient.ExternallyManaged,
-            !SupportsDelayedDelivery,
+            disableUnrestrictedDelayedDelivery,
             ReserveBytesInMessageSizeCalculation
         );
 
@@ -352,7 +352,7 @@ public partial class SqsTransport : TransportDefinition
             var queueCreator = new QueueCreator(SqsClient, QueueCache, S3, MaxTimeToLive, QueueDelayTime);
 
             var createQueueTasks = sendingAddresses.Select(x => queueCreator.CreateQueueIfNecessary(x, false, cancellationToken))
-                .Concat(infra.Receivers.Values.Select(x => queueCreator.CreateQueueIfNecessary(x.ReceiveAddress, SupportsDelayedDelivery, cancellationToken))).ToArray();
+                .Concat(infra.Receivers.Values.Select(x => queueCreator.CreateQueueIfNecessary(x.ReceiveAddress, !disableUnrestrictedDelayedDelivery, cancellationToken))).ToArray();
 
             await Task.WhenAll(createQueueTasks).ConfigureAwait(false);
         }
@@ -389,6 +389,7 @@ public partial class SqsTransport : TransportDefinition
 
     static readonly TimeSpan MaxTimeToLiveUpperBound = TimeSpan.FromDays(14);
     static readonly TimeSpan MaxTimeToLiveLowerBound = TimeSpan.FromSeconds(60);
+    readonly bool disableUnrestrictedDelayedDelivery;
     (IAmazonSQS Instance, bool ExternallyManaged) sqsClient;
     (IAmazonSimpleNotificationService Instance, bool ExternallyManaged) snsClient;
 }

--- a/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
+++ b/src/NServiceBus.Transport.SQS/Configure/SqsTransportInfrastructure.cs
@@ -18,7 +18,7 @@ class SqsTransportInfrastructure : TransportInfrastructure
         S3Settings s3Settings, PolicySettings policySettings, int queueDelayTimeSeconds,
         int? visibilityTimeoutInSeconds, TimeSpan maxAutoMessageVisibilityRenewalDuration, string topicNamePrefix,
         bool doNotWrapOutgoingMessages,
-        bool shouldDisposeSqsClient, bool shouldDisposeSnsClient, bool disableDelayedDelivery,
+        bool shouldDisposeSqsClient, bool shouldDisposeSnsClient, bool disableUnrestrictedDelayedDelivery,
         long reserveBytesInMessageSizeCalculation)
     {
         this.sqsClient = sqsClient;
@@ -29,7 +29,7 @@ class SqsTransportInfrastructure : TransportInfrastructure
         s3Client = s3Settings?.S3Client;
         shouldDisposeS3Client = s3Settings is { ShouldDisposeS3Client: true };
         Receivers = receiverSettings
-            .Select(receiverSetting => CreateMessagePump(receiverSetting, sqsClient, snsClient, queueCache, hostSettings.SetupInfrastructure, disableDelayedDelivery, topicCache, s3Settings, policySettings, queueDelayTimeSeconds, visibilityTimeoutInSeconds, maxAutoMessageVisibilityRenewalDuration, topicNamePrefix, hostSettings.CriticalErrorAction))
+            .Select(receiverSetting => CreateMessagePump(receiverSetting, sqsClient, snsClient, queueCache, hostSettings.SetupInfrastructure, disableUnrestrictedDelayedDelivery, topicCache, s3Settings, policySettings, queueDelayTimeSeconds, visibilityTimeoutInSeconds, maxAutoMessageVisibilityRenewalDuration, topicNamePrefix, hostSettings.CriticalErrorAction))
             .ToDictionary(x => x.Id, x => x);
 
         Dispatcher = new MessageDispatcher(hostSettings.CoreSettings, sqsClient, snsClient, queueCache, topicCache, s3Settings,
@@ -37,7 +37,7 @@ class SqsTransportInfrastructure : TransportInfrastructure
     }
 
     static IMessageReceiver CreateMessagePump(ReceiveSettings receiveSettings, IAmazonSQS sqsClient,
-        IAmazonSimpleNotificationService snsClient, QueueCache queueCache, bool setupInfrastructure, bool disableDelayedDelivery,
+        IAmazonSimpleNotificationService snsClient, QueueCache queueCache, bool setupInfrastructure, bool disableUnrestrictedDelayedDelivery,
         TopicCache topicCache, S3Settings s3Settings, PolicySettings policySettings, int queueDelayTimeSeconds,
         int? visibilityTimeoutInSeconds, TimeSpan maxAutoMessageVisibilityRenewalDuration, string topicNamePrefix,
         Action<string, Exception, CancellationToken> criticalErrorAction)
@@ -45,7 +45,7 @@ class SqsTransportInfrastructure : TransportInfrastructure
         var receiveAddress = ToTransportAddressCore(receiveSettings.ReceiveAddress, queueCache);
         var subManager = new SubscriptionManager(sqsClient, snsClient, receiveAddress, queueCache, topicCache, policySettings, topicNamePrefix, setupInfrastructure);
 
-        return new MessagePump(receiveSettings.Id, receiveAddress, receiveSettings.ErrorQueue, receiveSettings.PurgeOnStartup, sqsClient, queueCache, s3Settings, subManager, queueDelayTimeSeconds, visibilityTimeoutInSeconds, maxAutoMessageVisibilityRenewalDuration, criticalErrorAction, setupInfrastructure, disableDelayedDelivery);
+        return new MessagePump(receiveSettings.Id, receiveAddress, receiveSettings.ErrorQueue, receiveSettings.PurgeOnStartup, sqsClient, queueCache, s3Settings, subManager, queueDelayTimeSeconds, visibilityTimeoutInSeconds, maxAutoMessageVisibilityRenewalDuration, criticalErrorAction, setupInfrastructure, disableUnrestrictedDelayedDelivery);
     }
 
     public override async Task Shutdown(CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/DelayedMessagesPump.cs
@@ -28,12 +28,12 @@ class DelayedMessagesPump(string receiveAddress, IAmazonSQS sqsClient, QueueCach
 
         if (queueAttributes.DelaySeconds < queueDelayTimeSeconds)
         {
-            throw new Exception($"Delayed delivery queue '{delayedDeliveryQueueName}' has a Delivery Delay of '{TimeSpan.FromSeconds(queueAttributes.DelaySeconds)}'. It should be less than '{TimeSpan.FromSeconds(queueDelayTimeSeconds)}'.");
+            throw new Exception($"Delayed delivery queue '{delayedDeliveryQueueName}' has a Delivery Delay of '{TimeSpan.FromSeconds(queueAttributes.DelaySeconds)}'. It should be at least '{TimeSpan.FromSeconds(queueDelayTimeSeconds)}'.");
         }
 
         if (queueAttributes.MessageRetentionPeriod < (int)TransportConstraints.DelayedDeliveryQueueMessageRetentionPeriod.TotalSeconds)
         {
-            throw new Exception($"Delayed delivery queue '{delayedDeliveryQueueName}' has a Message Retention Period of '{TimeSpan.FromSeconds(queueAttributes.MessageRetentionPeriod)}'. It should be less than '{TransportConstraints.DelayedDeliveryQueueMessageRetentionPeriod}'.");
+            throw new Exception($"Delayed delivery queue '{delayedDeliveryQueueName}' has a Message Retention Period of '{TimeSpan.FromSeconds(queueAttributes.MessageRetentionPeriod)}'. It should be at least '{TransportConstraints.DelayedDeliveryQueueMessageRetentionPeriod}'.");
         }
 
         if (queueAttributes.Attributes.ContainsKey("RedrivePolicy"))

--- a/src/NServiceBus.Transport.SQS/Receiving/MessagePump.cs
+++ b/src/NServiceBus.Transport.SQS/Receiving/MessagePump.cs
@@ -7,7 +7,7 @@ using Amazon.SQS;
 
 class MessagePump : IMessageReceiver
 {
-    readonly bool disableDelayedDelivery;
+    readonly bool disableUnrestrictedDelayedDelivery;
     readonly InputQueuePump inputQueuePump;
     readonly DelayedMessagesPump delayedMessagesPump;
 
@@ -24,11 +24,11 @@ class MessagePump : IMessageReceiver
         TimeSpan maxAutoMessageVisibilityRenewalDuration,
         Action<string, Exception, CancellationToken> criticalErrorAction,
         bool setupInfrastructure,
-        bool disableDelayedDelivery)
+        bool disableUnrestrictedDelayedDelivery)
     {
-        this.disableDelayedDelivery = disableDelayedDelivery;
+        this.disableUnrestrictedDelayedDelivery = disableUnrestrictedDelayedDelivery;
         inputQueuePump = new InputQueuePump(receiverId, receiveAddress, errorQueueAddress, purgeOnStartup, sqsClient, queueCache, s3Settings, subscriptionManager, criticalErrorAction, visibilityTimeoutInSeconds, maxAutoMessageVisibilityRenewalDuration, setupInfrastructure);
-        if (!disableDelayedDelivery)
+        if (!disableUnrestrictedDelayedDelivery)
         {
             delayedMessagesPump =
                 new DelayedMessagesPump(receiveAddress, sqsClient, queueCache, queueDelayTimeSeconds);
@@ -38,7 +38,7 @@ class MessagePump : IMessageReceiver
     public async Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, CancellationToken cancellationToken = default)
     {
         await inputQueuePump.Initialize(limitations, onMessage, onError, cancellationToken).ConfigureAwait(false);
-        if (!disableDelayedDelivery)
+        if (!disableUnrestrictedDelayedDelivery)
         {
             await delayedMessagesPump.Initialize(cancellationToken).ConfigureAwait(false);
         }
@@ -47,7 +47,7 @@ class MessagePump : IMessageReceiver
     public async Task StartReceive(CancellationToken cancellationToken = default)
     {
         await inputQueuePump.StartReceive(cancellationToken).ConfigureAwait(false);
-        if (!disableDelayedDelivery)
+        if (!disableUnrestrictedDelayedDelivery)
         {
             delayedMessagesPump.Start(cancellationToken);
         }
@@ -55,7 +55,7 @@ class MessagePump : IMessageReceiver
 
     public Task StopReceive(CancellationToken cancellationToken = default)
     {
-        var stopDelayed = !disableDelayedDelivery
+        var stopDelayed = !disableUnrestrictedDelayedDelivery
             ? delayedMessagesPump.Stop(cancellationToken)
             : Task.CompletedTask;
         var stopPump = inputQueuePump.StopReceive(cancellationToken);


### PR DESCRIPTION
Fixes #3113 

The `disableUnrestrictedDelayedDelivery` parameter in the public `SqsTransport` constructors is being used to enable/disable NServiceBus delayed delivery altogether, but there should be a distinction:

- `disableUnrestrictedDelayedDelivery` is used to enable delays beyond the built-in SQS limit of 15 minutes, but delays under 15 minutes are still valid.
- `supportsDelayedDelivery` in the transport definition used by NServiceBus enables whether the endpoint can configure **_any_** delays at all, including the delayed retries, which are enabled by default. 

Right now, the only way to disable unrestricted delayed delivery in the SQS transport without NServiceBus throwing an error is also to disable delayed retries by [setting the delayed retry count to 0](https://docs.particular.net/nservicebus/recoverability/configure-delayed-retries#disabling-through-code).

This decouples the transport-specific `disableUnrestrictedDelayedDelivery` parameter from the NServiceBus transport definition's `supportsDelayedDelivery` parameter.